### PR TITLE
Adds a note about out of memory errors and provides a way to fix that

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -196,6 +196,12 @@ To build a single package:
 colcon build --packages-select PACKAGE_NAME
 ```
 
+To restrict the number of jobs to prevent out of memory issues:
+
+```bash
+MAKEFLAGS="-j<Number of jobs> " colcon build --executor sequential
+```
+
 Visit [colcon documentation](https://colcon.readthedocs.io/en/released/#) to view more `colcon` build and test options.
 
 If there are no errors, all the binaries should be ready to use.

--- a/fortress/install_ubuntu_src.md
+++ b/fortress/install_ubuntu_src.md
@@ -200,6 +200,12 @@ To build a single package:
 colcon build --packages-select PACKAGE_NAME
 ```
 
+To restrict the number of jobs to prevent out of memory issues:
+
+```bash
+MAKEFLAGS="-j<Number of jobs> " colcon build --executor sequential
+```
+
 Visit [colcon documentation](https://colcon.readthedocs.io/en/released/#) to view more `colcon` build and test options.
 
 If there are no errors, all the binaries should be ready to use.

--- a/garden/install_ubuntu_src.md
+++ b/garden/install_ubuntu_src.md
@@ -170,6 +170,12 @@ To build a single package:
 colcon build --packages-select PACKAGE_NAME
 ```
 
+To restrict the number of jobs to prevent out of memory issues:
+
+```bash
+MAKEFLAGS="-j<Number of jobs> " colcon build --executor sequential
+```
+
 Visit [colcon documentation](https://colcon.readthedocs.io/en/released/#) to view more `colcon` build and test options.
 
 If there are no errors, all the binaries should be ready to use.


### PR DESCRIPTION
# 🦟 Bug fix

Fixes gz-physics #349

## Summary
Adds a note about possible out of memory errors and provides a way to fix that. I changed the documentation in here rather than gz-physics because this error occurs during parallel building of packages.

## Checklist
- [+] Signed all commits for DCO
- [ ] Added tests
- [+] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

