### PR TITLE
[9] Rename Ignition in the Roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -1,8 +1,8 @@
-# Ignition Roadmap
+# Gazebo Roadmap
 
-This page describes planned work for Ignition. The set of planned
+This page describes planned work for Gazebo. The set of planned
 features and development efforts should provide insight into the overall
-direction of Ignition. If you would like to
+direction of Gazebo. If you would like to
 see other features on the roadmap, then please get in touch with us at
 info@openrobotics.org.
 
@@ -11,20 +11,20 @@ info@openrobotics.org.
 ## 2022 Q1 (Jan - Mar) / Q2 (Apr - Jun) - ongoing
 
 * **Out-of-box experience**: Improve end-user experience
-    * [All open tickets](https://github.com/search?q=org%3Aignitionrobotics+label%3A%22OOBE+%F0%9F%93%A6%E2%9C%A8%22&state=open&type=Issues)
-    * [Status](https://github.com/orgs/ignitionrobotics/projects/3?card_filter_query=label%3A%22oobe+%F0%9F%93%A6%E2%9C%A8%22)
+    * [All open tickets](https://github.com/search?q=org%3Agazebosim+label%3A%22OOBE+%F0%9F%93%A6%E2%9C%A8%22&state=open&type=Issues)
+    * [Status](https://github.com/orgs/gazebosim/projects/3?card_filter_query=label%3A%22oobe+%F0%9F%93%A6%E2%9C%A8%22)
 
 ## Feature Roadmap
 
-A number of features are planned for specific releases of Ignition. The
+A number of features are planned for specific releases of Gazebo. The
 features listed here derive from the Quarterly Roadmap, listed above, and other
 ongoing projects.  See the [Release Features](/docs/all/release-features) page
-for a list of features already available in each release of Ignition.
+for a list of features already available in each release of Gazebo.
 
-A named release of Ignition, such as Acropolis or Blueprint, is tied to
+A named release of Gazebo, such as Acropolis or Blueprint, is tied to
 a set of [library](/libs) major versions. Our
 [development and release pattern](/docs/all/releases) allows us to distribute
-patch and minor updates into a stable Ignition version. For example, if a new
+patch and minor updates into a stable Gazebo version. For example, if a new
 feature does not break API/ABI then we will target the feature to the oldest
 compatible non-EOL release and propagate the feature forward.
 
@@ -43,7 +43,7 @@ compatible non-EOL release and propagate the feature forward.
 1. [Bazel build files.](https://github.com/gazebosim/gz-bazel)
 1. [Waves and hydrodynamics for water surface vehicles.](https://github.com/gazebosim/gz-sim/issues/1247)
 1. [Save more changed components to SDF.](https://github.com/gazebosim/gz-sim/issues/1312)
-1. [Improved Windows support.](https://github.com/search?q=org%3Aignitionrobotics+label%3AWindows&state=open&type=Issues)
+1. [Improved Windows support.](https://github.com/search?q=org%3Agazebosim+label%3AWindows&state=open&type=Issues)
 1. Custom skybox from SDF.
 1. Gz3D: support heightmaps, skybox and particles.
 
@@ -58,11 +58,11 @@ compatible non-EOL release and propagate the feature forward.
 * In progress
     1. [Force/torque visualization.](https://github.com/gazebosim/gz-sim/issues/1155)
     1. [Reset API.](https://github.com/gazebosim/gz-sim/issues/1107)
-    1. [Parameters in Ignition Transport.](https://github.com/gazebosim/gz-sim/pull/1280)
-    1. [Satisfying ASAN for Ignition Math.](https://github.com/gazebosim/gz-math/issues/370)
-    1. [Mimic joint type.](https://github.com/ignitionrobotics/sdf_tutorials/pull/62)
+    1. [Parameters in Gazebo Transport.](https://github.com/gazebosim/gz-sim/pull/1280)
+    1. [Satisfying ASAN for Gazebo Math.](https://github.com/gazebosim/gz-math/issues/370)
+    1. [Mimic joint type.](https://github.com/gazebosim/sdf_tutorials/pull/62)
     1. [Added mass in SDF.](https://github.com/gazebosim/gz-sim/issues/1462)
-    1. [SDF APIs to prevent console logging.](https://github.com/ignitionrobotics/sdformat/issues/820)
+    1. [SDF APIs to prevent console logging.](https://github.com/gazebosim/sdformat/issues/820)
     1. [Renaming Ignition to Gazebo.](https://community.gazebosim.org/t/a-new-era-for-gazebo/1356)
     1. [glTF and GLB mesh support.](https://github.com/gazebosim/gz-common/issues/344)
     1. [Download Fuel models on the background](https://github.com/gazebosim/gz-sim/issues/1260)
@@ -76,7 +76,7 @@ compatible non-EOL release and propagate the feature forward.
 
 Please see the [Releases](/docs/all/releases) for the timeline of and information about future distributions.
 
-## Contributing to Ignition
+## Contributing to Gazebo
 
 Looking for something to work on, or just want to help out? Here are a few
 resources to get you going.


### PR DESCRIPTION
Changes `Ignition` to `Gazebo` in `roadmap.md`.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
