### PR TITLE
Extend Garden's support by 2 months to match ROS Iron

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -14,15 +14,15 @@ A Gazebo release follows the form "Gazebo Codename", for example Gazebo Acropoli
 
 | Name                                                     | Date      | EOL date  | Notes |
 |----------------------------------------------------------|-----------|-----------|-------|
-| [Acropolis](https://gazebosim.org/docs/acropolis) | Feb, 2019 | Sep, 2019 | EOL   |
-| [Blueprint](https://gazebosim.org/docs/blueprint) | May, 2019 | Dec, 2020 | EOL   |
-| [Citadel](https://gazebosim.org/docs/citadel)     | Dec, 2019 | Dec, 2024 | LTS   |
-| [Dome](https://gazebosim.org/docs/dome)           | Sep, 2020 | Dec, 2021 | EOL   |
-| [Edifice](https://gazebosim.org/docs/edifice)     | Mar, 2021 | Mar, 2022 | EOL   |
-| [Fortress](https://gazebosim.org/docs/fortress)   | Sep, 2021 | Sep, 2026 | LTS   |
-| [Garden](https://gazebosim.org/docs/garden)       | Sep, 2022 | Sep, 2024 |       |
-| Gazebo-H                                               | Sep, 2023 | Sep, 2028 | LTS   |
-| Gazebo-I                                               | Sep, 2024 | Sep, 2026 |       |
+| [Acropolis](https://gazebosim.org/docs/acropolis)        | Feb, 2019 | Sep, 2019 | EOL   |
+| [Blueprint](https://gazebosim.org/docs/blueprint)        | May, 2019 | Dec, 2020 | EOL   |
+| [Citadel](https://gazebosim.org/docs/citadel)            | Dec, 2019 | Dec, 2024 | LTS   |
+| [Dome](https://gazebosim.org/docs/dome)                  | Sep, 2020 | Dec, 2021 | EOL   |
+| [Edifice](https://gazebosim.org/docs/edifice)            | Mar, 2021 | Mar, 2022 | EOL   |
+| [Fortress](https://gazebosim.org/docs/fortress)          | Sep, 2021 | Sep, 2026 | LTS   |
+| [Garden](https://gazebosim.org/docs/garden)              | Sep, 2022 | Nov, 2024 |       |
+| Gazebo-H                                                 | Sep, 2023 | Sep, 2028 | LTS   |
+| Gazebo-I                                                 | Sep, 2024 | Sep, 2026 |       |
 
 ## Library Versions
 


### PR DESCRIPTION
ROS Iron will be supported until November 2024: https://docs.ros.org/en/humble/Releases.html

In order to officially pair Garden with Iron, we'll increase its support by 2 months from the originally planned September 2024 to November 2024.