### PR TITLE
Use ROS 2 repo on Jammy, not ROS

### DIFF
--- a/fortress/install_ubuntu_src.md
+++ b/fortress/install_ubuntu_src.md
@@ -61,7 +61,7 @@ export PATH=$PATH:$HOME/.local/bin/
 An alternative method is to use the `.deb` packages available on Debian or Ubuntu:
 
 ```bash
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list'
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install python3-vcstool python3-colcon-common-extensions

--- a/garden/install_ubuntu_src.md
+++ b/garden/install_ubuntu_src.md
@@ -61,7 +61,7 @@ export PATH=$PATH:$HOME/.local/bin/
 An alternative method is to use the `.deb` packages available on Debian or Ubuntu:
 
 ```bash
-sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
+sudo sh -c 'echo "deb http://packages.ros.org/ros2/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros2-latest.list'
 curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install python3-vcstool python3-colcon-common-extensions

--- a/garden/install_ubuntu_src.md
+++ b/garden/install_ubuntu_src.md
@@ -123,7 +123,7 @@ The command below will install all dependencies in Ubuntu:
 
 ```bash
 sudo apt -y install \
-  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gazebo\|sdf/d' | tr '\n' ' ')
+  $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 ```
 
 ## Building the Gazebo Libraries


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

We can get tools from the ROS 2 repo for both Jammy and Focal, but only ROS 2 works for Jammy.

Also fixed the `sed` from `gazebo` to `gz`, which is the string present on the package names.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
