### PR TITLE
Added development structure, reversed order to release features

### DIFF
--- a/development.md
+++ b/development.md
@@ -1,0 +1,9 @@
+# Gazebo Development
+
+
+The following guides describe how Gazebo is developed, maintained, and
+released.
+
+* [Continuous Integration](ci)
+* [Contributing](contributing)
+* [Release process](release)

--- a/development.md
+++ b/development.md
@@ -1,6 +1,5 @@
 # Gazebo Development
 
-
 The following guides describe how Gazebo is developed, maintained, and
 released.
 

--- a/index.yaml
+++ b/index.yaml
@@ -31,24 +31,27 @@ pages:
     title: Releases
     file: releases.md
     description: Past, current, and future release information.
-  - name: contributing
-    title: Contributing
-    file: contributing.md
-    description: How to contribute to Gazebo.
+  - name: development 
+    title: Development
+    file: development.md
+    description: Gazebo development information
+    children:
+      - name: ci
+        title: Continuous Integration
+        file: ci.md
+        description: Continuous Integration overview.
+      - name: contributing
+        title: Contributing
+        file: contributing.md
+        description: How to contribute to Gazebo.
+      - name: release
+        title: Release process
+        file: release.md
+        description: Release process overview.
   - name: architecture
-    title: Architecture
+    title: Sim Architecture
     file: architecture.md
     description: Gazebo Sim's architecture overview.
-    unlisted: true
-  - name: release
-    title: Release process
-    file: release.md
-    description: Release process overview.
-    unlisted: true
-  - name: ci
-    title: Continuous Integration
-    file: ci.md
-    description: Continuous Integration overview.
     unlisted: true
 releases:
   - name: garden

--- a/index.yaml
+++ b/index.yaml
@@ -36,14 +36,14 @@ pages:
     file: development.md
     description: Gazebo development information
     children:
-      - name: ci
-        title: Continuous Integration
-        file: ci.md
-        description: Continuous Integration overview.
       - name: contributing
         title: Contributing
         file: contributing.md
         description: How to contribute to Gazebo.
+      - name: ci
+        title: Continuous Integration
+        file: ci.md
+        description: Continuous Integration overview.
       - name: release
         title: Release process
         file: release.md
@@ -52,7 +52,6 @@ pages:
     title: Sim Architecture
     file: architecture.md
     description: Gazebo Sim's architecture overview.
-    unlisted: true
 releases:
   - name: garden
     lts: false

--- a/release.md
+++ b/release.md
@@ -94,7 +94,7 @@ stability of the software:
      (see [the homebrew-simulation issue](https://github.com/osrf/homebrew-simulation/issues/1314)
      for more information).
 
-### Using the `gzdev repository` command
+### Using the gzdev repository command
 
 The [gzdev repository](https://github.com/gazebo-tooling/gzdev#repository)
 command is a convenient way to configure Ubuntu / Debian systems to use a

--- a/release_features.md
+++ b/release_features.md
@@ -5,105 +5,137 @@ Here you will find the set of features that are available in each release.
 Take a look at the [Roadmap](/docs/roadmap) for information about upcoming
 features, some of which may land in released versions of Gazebo.
 
-## Acropolis (EOL)
+## Fortress
 
-The first major release of Gazebo focused on the basics of simulation. The basics primarily encompassed integration of physics, sensors, graphical tools, and programmatic interfaces.
-
-1. Support for [DART](https://dartsim.github.io/) in [Gazebo Physics](/libs/physics).
-2. Ogre1.9 and Ogre2.1 support in [Gazebo Rendering](/libs/rendering)
-3. [Entity Component System](https://en.wikipedia.org/wiki/Entity_component_system) based simulation engine in [Gazebo Sim](/libs/gazebo).
-4. A sensor suite that includes contact sensor, logical camera, monocular camera, depth camera, LIDAR, magnetometer, altimeter, and IMU is available through [Gazebo Sensors](/libs/sensors) and [Gazebo Sim](/libs/gazebo).
-5. [Launch system](/libs/launch) capable of running and managing a set of plugins and executables.
-6. Cloud-hosted simulation assets provided by [app.gazebosim.org](https://app.gazebosim.org).
-7. Distributed simulation using lock-stepping.
-8. Dynamic loading/unloading of simulation models based on the location of performer, usually a robot.
-9. Simulation state logging.
-10. Plugin-based GUI system based on [QtQuick](https://en.wikipedia.org/wiki/Qt_Quick) and [Material Design](https://material.io/design/). Available
-    plugins include 3D scene viewer, image viewer, topic echo, topic
-    publisher, world control, and world statistics.
-
-The Acropolis collection is composed by many different Gazebo libraries. The
-collection assures that all libraries all compatible and can be used together.
-
-| Library name       | Version       | Changelog     |
-| ------------------ |:-------------:|:-------------:|
-|   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
-|   gz-common       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common3/Changelog.md)    |
-|   gz-fuel-tools   |       3.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools3/Changelog.md)    |
-|   gz-sim          |       1.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo1/Changelog.md)     |
-|   gz-gui          |       1.x     |       None       |
-|   gz-launch       |       0.x     |       None       |
-|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)     |
-|   gz-msgs         |       3.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs3/Changelog.md)     |
-|   gz-physics      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics1/Changelog.md)      |
-|   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
-|   gz-rendering    |       1.x     |       None      |
-|   gz-sensors      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors1/Changelog.md)      |
-|   gz-tools        |       0.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools0/Changelog.md)     |
-|   gz-transport    |       6.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport6/Changelog.md)      |
-|   sdformat         |       8.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf8/Changelog.md)        |
-
-
-## Blueprint (EOL)
-
-1. [Physically based rendering (PBR)](https://en.wikipedia.org/wiki/Physically_based_rendering) materials.
-1. Air pressure, RGBD and stereo camera sensors.
-1. Global wind model.
-1. Joint state publisher.
-1. Support for UAVs.
-1. Integration of `ign` command line tool into Gazebo Sim.
-1. Logging and playback of simulation state.
-1. Command line tools to control log playback.
-1. Battery model based on vehicle motion and rechargeable batteries.
-1. Integration of [Google benchmark](https://github.com/google/benchmark) for performance metrics and analysis.
-1. Tracked vehicle support.
-1. Breadcrumbs plugin.
-1. Position-based PID controller.
-1. Improved resource path handling.
-1. Loading custom physics engine plugins.
-1. Plugin that publishes a user specified message on an output topic in response to an input message.
-1. Noise for RGBD camera.
-1. Load worlds from Fuel.
-1. [Customizable GUI layout](https://gazebosim.org/api/gazebo/3.3/gui_config.html).
-1. [Detachable joints](https://gazebosim.org/api/gazebo/4.0/detachablejoints.html)
-1. GUI tools:
-    * GUI tools for model placement, and a new Scene Tree widget.
-    * Translate and rotate models.
-    * Entity tree.
-    * Video recorder.
-    * Move to models.
-    * Follow model.
-    * Delete model.
-    * Grid.
-    * Drag-and-drop models from Fuel to Gazebo Sim UI.
-    * Preset view angles.
-    * Hotkeys for transform modes and snapping.
-    * Entity selection.
-    * [Align models](https://gazebosim.org/docs/dome/manipulating_models#align-tool).
-    * Insert simple shapes.
-    * Insert models from online sources and local directories.
-    * Log playback scrubber.
-    * Save worlds.
-    * Tape measure.
+1. [Headless simulation using EGL.](https://github.com/gazebosim/gz-rendering/issues/223)
+1. [Refactor ECM::Each for performance.](https://github.com/gazebosim/gz-sim/issues/711)
+1. [Upgrade to Ogre 2.2.](https://github.com/gazebosim/gz-rendering/issues/223)
+1. [Improve `<pose>` tag on SDFormat.](https://github.com/osrf/sdformat/issues/252)
+1. [Heightmaps on Ogre 2](https://github.com/gazebosim/gz-rendering/issues/187)
+1. [Spherical coordinates](https://github.com/gazebosim/gz-sim/issues/981)
+1. [Buoyancy engine](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/examples/worlds/buoyancy_engine.sdf)
+1. [Control lights from ROS 2](https://github.com/gazebosim/ros_gz/pull/187)
+1. [Python interface to Gazebo.](https://github.com/gazebosim/gz-sim/issues/789)
+1. [Custom shaders.](https://github.com/gazebosim/gz-sim/issues/657)
+1. [Visual plugins.](https://github.com/gazebosim/gz-sim/issues/265)
+1. [Rendering waves.](https://github.com/gazebosim/gz-rendering/pull/541)
+1. [Generic comms system.](https://github.com/gazebosim/gz-sim/pull/1416)
+1. [Wheel slip commands.](https://github.com/gazebosim/gz-sim/pull/1241)
+1. [USD importer / exporter.](https://github.com/gazebosim/sdformat/tree/sdf12/examples/usdConverter)
+1. [Bridge Gazebo services to ROS 2 services.](https://github.com/gazebosim/ros_ign/pull/211)
+1. [Omniverse application](https://github.com/gazebosim/gz-omni)
+1. [Pose and Twist with covariance.](https://github.com/gazebosim/gz-msgs/pull/224)
+1. Sensors
+  1. [Custom sensors.](https://gazebosim.org/api/sensors/6.0/custom_sensors.html)
+  1. [Segmentation camera.](https://gazebosim.org/api/sensors/6.0/segmentationcamera_igngazebo.html)
+  1. [Joint force-torque sensor.](https://github.com/gazebosim/gz-sensors/issues/25)
+  1. [GPS / NavSat sensor.](https://github.com/gazebosim/gz-sensors/issues/23)
+  1. [Triggered cameras.](https://github.com/gazebosim/gz-sensors/issues/185)
+1. GUI features
+    1. [Consolidate Scene3D with GzScene3D](https://github.com/gazebosim/gz-gui/issues/137)
+    1. [Visualize wireframes](https://github.com/gazebosim/gz-sim/pull/816)
+    1. [Visualize transparent](https://github.com/gazebosim/gz-sim/pull/878)
+    1. [Visualize inertia](https://github.com/gazebosim/gz-sim/issues/111)
+    1. [Visualize center of mass](https://github.com/gazebosim/gz-sim/issues/110)
+    1. [Visualize joints](https://github.com/gazebosim/gz-sim/issues/106)
+    1. [Orthographic view](https://github.com/gazebosim/gz-sim/issues/103)
+    1. [System inspector.](https://github.com/gazebosim/gz-sim/issues/191)
 
 | Library name       | Version       | Changelog     |
 | ------------------ |:-------------:|:-------------:|
 |   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
-|   gz-common       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common3/Changelog.md)    |
-|   gz-fuel-tools   |       3.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools3/Changelog.md)    |
-|   gz-sim          |       2.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo2/Changelog.md)     |
-|   gz-gui          |       2.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui2/Changelog.md)       |
-|   gz-launch       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch1/Changelog.md)
+|   gz-common       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common4/Changelog.md)    |
+|   gz-fuel-tools   |       7.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools7/Changelog.md)    |
+|   gz-sim          |       6.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/Changelog.md)     |
+|   gz-gui          |       6.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui6/Changelog.md)       |
+|   gz-launch       |       5.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch5/Changelog.md)
 |   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
-|   gz-msgs         |       4.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs4/Changelog.md)
-|   gz-physics      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics1/Changelog.md)
+|   gz-msgs         |       8.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs8/Changelog.md)
+|   gz-physics      |       5.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics5/Changelog.md)
 |   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
-|   gz-rendering    |       2.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering2/Changelog.md)      |
-|   gz-sensors      |       2.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors2/Changelog.md)      |
-|   gz-tools        |       0.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools0/Changelog.md)
-|   gz-transport    |       7.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport7/Changelog.md)
-|   sdformat         |       8.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf8/Changelog.md)        |
+|   gz-rendering    |       6.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering6/Changelog.md)      |
+|   gz-sensors      |       6.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors6/Changelog.md)      |
+|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
+|   gz-transport    |      11.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport11/Changelog.md)      |
+|   gz-utils        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-utils/blob/ign-utils1/Changelog.md)      |
+|   sdformat         |      12.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf12/Changelog.md)        |
 
+## Edifice (EOL)
+
+1. New utility library with minimal dependencies: [Gazebo Utils](https://github.com/gazebosim/gz-utils/).
+1. [Sky box support.](https://github.com/gazebosim/gz-rendering/issues/98)
+1. [Lightmap support.](https://github.com/gazebosim/gz-sim/pull/471)
+1. [Capsule and ellipsoid geometries.](https://github.com/osrf/sdformat/issues/376)
+1. [SDF model composition.](https://github.com/osrf/sdformat/issues/278)
+1. [SDFormat interface for non-SDF models.](http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&#1-5-minimal-libsdformat-interface-types-for-non-sdformat-models)
+1. [Choose render order for overlapping polygons.](https://github.com/gazebosim/gz-rendering/pull/188)
+1. [Light visualization.](https://github.com/gazebosim/gz-sim/issues/193)
+1. [Spawn lights from the GUI.](https://github.com/gazebosim/gz-sim/issues/119)
+1. [Mecanum wheel controller.](https://github.com/gazebosim/gz-sim/issues/579)
+1. [Hydrodynamics.](https://gazebosim.org/api/gazebo/5.0/classignition_1_1gazebo_1_1systems_1_1Hydrodynamics.html)
+1. [Ocean currents.](https://github.com/gazebosim/gz-sim/pull/800)
+1. [Hook command line tool to binaries instead of libraries.](https://github.com/gazebosim/gz-tools/issues/7)
+1. [Heightmap support using Ogre 1 and DART.](https://github.com/gazebosim/gz-sim/issues/237)
+1. [Turn lights on and off.](https://github.com/gazebosim/gz-sim/pull/1343)
+1. [Toggle light visualization.](https://github.com/gazebosim/gz-sim/issues/638)
+1. [Model photoshoot plugin.](https://github.com/gazebosim/gz-sim/pull/1331)
+
+| Library name       | Version       | Changelog     |
+| ------------------ |:-------------:|:-------------:|
+|   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
+|   gz-common       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common4/Changelog.md)    |
+|   gz-fuel-tools   |       6.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools6/Changelog.md)    |
+|   gz-sim          |       5.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo5/Changelog.md)     |
+|   gz-gui          |       5.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui5/Changelog.md)       |
+|   gz-launch       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch4/Changelog.md)
+|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
+|   gz-msgs         |       7.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs7/Changelog.md)
+|   gz-physics      |       4.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics4/Changelog.md)
+|   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
+|   gz-rendering    |       5.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering5/Changelog.md)      |
+|   gz-sensors      |       5.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors5/Changelog.md)      |
+|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
+|   gz-transport    |      10.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport10/Changelog.md)      |
+|   gz-utils        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-utils/blob/ign-utils1/Changelog.md)      |
+|   sdformat         |      11.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf11/Changelog.md)        |
+
+## Dome (EOL)
+
+1. Particle effects on [Gazebo Rendering](https://gazebosim.org/api/rendering/4.1/particles.html) and [Gazebo Sim](https://github.com/gazebosim/gz-sim/blob/ign-gazebo4/examples/worlds/particle_emitter.sdf).
+1. Actor plugins.
+1. Efficient skeleton animations.
+1. [Optical tactile sensor plugin.](https://community.gazebosim.org/t/gsoc-2020-ignition-gazebo-optical-tactile-sensor-plugin/618)
+1. [Support entity names with spaces.](https://github.com/gazebosim/gz-sim/issues/239)
+1. Kinetic energy monitor plugin.
+1. [Texture-based thermal signature](https://gazebosim.org/api/sensors/4.1/thermalcameraigngazebo.html) for objects, visible from thermal camera.
+1. [Web visualization of running simulations](https://gazebosim.org/docs/dome/web_visualization).
+1. [Bullet physics engine.](https://github.com/gazebosim/gz-physics/issues/44)
+1. [Parametrized SDF files.](http://sdformat.org/tutorials?tut=param_passing_proposal)
+1. [libSDFormat now uses gz-cmake](https://github.com/gazebosim/sdformat/issues/181)
+1. GUI tools:
+    * [Plotting](https://community.gazebosim.org/t/gsoc-2020-plotting-tool-for-ignition/619)
+    * [Lidar visualization](https://community.gazebosim.org/t/gsoc-2020-sensor-data-visualization/638)
+    * [Configure physics real time factor and step size.](https://github.com/gazebosim/gz-sim/pull/536)
+    * [Configure lights from the GUI or transport.](https://github.com/gazebosim/gz-sim/issues/122)
+    * [Contact visualization.](https://github.com/gazebosim/gz-sim/issues/234)
+
+| Library name       | Version       | Changelog     |
+| ------------------ |:-------------:|:-------------:|
+|   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
+|   gz-common       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common3/Changelog.md)    |
+|   gz-fuel-tools   |       5.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools5/Changelog.md)    |
+|   gz-sim          |       4.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo4/Changelog.md)     |
+|   gz-gui          |       4.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui4/Changelog.md)       |
+|   gz-launch       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch3/Changelog.md)
+|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
+|   gz-msgs         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs6/Changelog.md)
+|   gz-physics      |       3.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics3/Changelog.md)
+|   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
+|   gz-rendering    |       4.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering4/Changelog.md)      |
+|   gz-sensors      |       4.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors4/Changelog.md)      |
+|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
+|   gz-transport    |       9.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport9/Changelog.md)      |
+|   sdformat         |      10.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf10/Changelog.md)        |
 
 ## Citadel (LTS)
 
@@ -166,137 +198,100 @@ collection assures that all libraries all compatible and can be used together.
 |   gz-transport    |       8.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport8/Changelog.md)      |
 |   sdformat         |       9.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf9/Changelog.md)        |
 
+## Blueprint (EOL)
 
-## Dome (EOL)
-
-1. Particle effects on [Gazebo Rendering](https://gazebosim.org/api/rendering/4.1/particles.html) and [Gazebo Sim](https://github.com/gazebosim/gz-sim/blob/ign-gazebo4/examples/worlds/particle_emitter.sdf).
-1. Actor plugins.
-1. Efficient skeleton animations.
-1. [Optical tactile sensor plugin.](https://community.gazebosim.org/t/gsoc-2020-ignition-gazebo-optical-tactile-sensor-plugin/618)
-1. [Support entity names with spaces.](https://github.com/gazebosim/gz-sim/issues/239)
-1. Kinetic energy monitor plugin.
-1. [Texture-based thermal signature](https://gazebosim.org/api/sensors/4.1/thermalcameraigngazebo.html) for objects, visible from thermal camera.
-1. [Web visualization of running simulations](https://gazebosim.org/docs/dome/web_visualization).
-1. [Bullet physics engine.](https://github.com/gazebosim/gz-physics/issues/44)
-1. [Parametrized SDF files.](http://sdformat.org/tutorials?tut=param_passing_proposal)
-1. [libSDFormat now uses gz-cmake](https://github.com/gazebosim/sdformat/issues/181)
+1. [Physically based rendering (PBR)](https://en.wikipedia.org/wiki/Physically_based_rendering) materials.
+1. Air pressure, RGBD and stereo camera sensors.
+1. Global wind model.
+1. Joint state publisher.
+1. Support for UAVs.
+1. Integration of `ign` command line tool into Gazebo Sim.
+1. Logging and playback of simulation state.
+1. Command line tools to control log playback.
+1. Battery model based on vehicle motion and rechargeable batteries.
+1. Integration of [Google benchmark](https://github.com/google/benchmark) for performance metrics and analysis.
+1. Tracked vehicle support.
+1. Breadcrumbs plugin.
+1. Position-based PID controller.
+1. Improved resource path handling.
+1. Loading custom physics engine plugins.
+1. Plugin that publishes a user specified message on an output topic in response to an input message.
+1. Noise for RGBD camera.
+1. Load worlds from Fuel.
+1. [Customizable GUI layout](https://gazebosim.org/api/gazebo/3.3/gui_config.html).
+1. [Detachable joints](https://gazebosim.org/api/gazebo/4.0/detachablejoints.html)
 1. GUI tools:
-    * [Plotting](https://community.gazebosim.org/t/gsoc-2020-plotting-tool-for-ignition/619)
-    * [Lidar visualization](https://community.gazebosim.org/t/gsoc-2020-sensor-data-visualization/638)
-    * [Configure physics real time factor and step size.](https://github.com/gazebosim/gz-sim/pull/536)
-    * [Configure lights from the GUI or transport.](https://github.com/gazebosim/gz-sim/issues/122)
-    * [Contact visualization.](https://github.com/gazebosim/gz-sim/issues/234)
+    * GUI tools for model placement, and a new Scene Tree widget.
+    * Translate and rotate models.
+    * Entity tree.
+    * Video recorder.
+    * Move to models.
+    * Follow model.
+    * Delete model.
+    * Grid.
+    * Drag-and-drop models from Fuel to Gazebo Sim UI.
+    * Preset view angles.
+    * Hotkeys for transform modes and snapping.
+    * Entity selection.
+    * [Align models](https://gazebosim.org/docs/dome/manipulating_models#align-tool).
+    * Insert simple shapes.
+    * Insert models from online sources and local directories.
+    * Log playback scrubber.
+    * Save worlds.
+    * Tape measure.
 
 | Library name       | Version       | Changelog     |
 | ------------------ |:-------------:|:-------------:|
 |   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
 |   gz-common       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common3/Changelog.md)    |
-|   gz-fuel-tools   |       5.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools5/Changelog.md)    |
-|   gz-sim          |       4.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo4/Changelog.md)     |
-|   gz-gui          |       4.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui4/Changelog.md)       |
-|   gz-launch       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch3/Changelog.md)
+|   gz-fuel-tools   |       3.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools3/Changelog.md)    |
+|   gz-sim          |       2.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo2/Changelog.md)     |
+|   gz-gui          |       2.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui2/Changelog.md)       |
+|   gz-launch       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch1/Changelog.md)
 |   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
-|   gz-msgs         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs6/Changelog.md)
-|   gz-physics      |       3.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics3/Changelog.md)
+|   gz-msgs         |       4.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs4/Changelog.md)
+|   gz-physics      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics1/Changelog.md)
 |   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
-|   gz-rendering    |       4.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering4/Changelog.md)      |
-|   gz-sensors      |       4.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors4/Changelog.md)      |
-|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
-|   gz-transport    |       9.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport9/Changelog.md)      |
-|   sdformat         |      10.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf10/Changelog.md)        |
+|   gz-rendering    |       2.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering2/Changelog.md)      |
+|   gz-sensors      |       2.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors2/Changelog.md)      |
+|   gz-tools        |       0.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools0/Changelog.md)
+|   gz-transport    |       7.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport7/Changelog.md)
+|   sdformat         |       8.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf8/Changelog.md)        |
 
-## Edifice (EOL)
+## Acropolis (EOL)
 
-1. New utility library with minimal dependencies: [Gazebo Utils](https://github.com/gazebosim/gz-utils/).
-1. [Sky box support.](https://github.com/gazebosim/gz-rendering/issues/98)
-1. [Lightmap support.](https://github.com/gazebosim/gz-sim/pull/471)
-1. [Capsule and ellipsoid geometries.](https://github.com/osrf/sdformat/issues/376)
-1. [SDF model composition.](https://github.com/osrf/sdformat/issues/278)
-1. [SDFormat interface for non-SDF models.](http://sdformat.org/tutorials?tut=composition_proposal&cat=pose_semantics_docs&#1-5-minimal-libsdformat-interface-types-for-non-sdformat-models)
-1. [Choose render order for overlapping polygons.](https://github.com/gazebosim/gz-rendering/pull/188)
-1. [Light visualization.](https://github.com/gazebosim/gz-sim/issues/193)
-1. [Spawn lights from the GUI.](https://github.com/gazebosim/gz-sim/issues/119)
-1. [Mecanum wheel controller.](https://github.com/gazebosim/gz-sim/issues/579)
-1. [Hydrodynamics.](https://gazebosim.org/api/gazebo/5.0/classignition_1_1gazebo_1_1systems_1_1Hydrodynamics.html)
-1. [Ocean currents.](https://github.com/gazebosim/gz-sim/pull/800)
-1. [Hook command line tool to binaries instead of libraries.](https://github.com/gazebosim/gz-tools/issues/7)
-1. [Heightmap support using Ogre 1 and DART.](https://github.com/gazebosim/gz-sim/issues/237)
-1. [Turn lights on and off.](https://github.com/gazebosim/gz-sim/pull/1343)
-1. [Toggle light visualization.](https://github.com/gazebosim/gz-sim/issues/638)
-1. [Model photoshoot plugin.](https://github.com/gazebosim/gz-sim/pull/1331)
+The first major release of Gazebo focused on the basics of simulation. The basics primarily encompassed integration of physics, sensors, graphical tools, and programmatic interfaces.
+
+1. Support for [DART](https://dartsim.github.io/) in [Gazebo Physics](/libs/physics).
+2. Ogre1.9 and Ogre2.1 support in [Gazebo Rendering](/libs/rendering)
+3. [Entity Component System](https://en.wikipedia.org/wiki/Entity_component_system) based simulation engine in [Gazebo Sim](/libs/gazebo).
+4. A sensor suite that includes contact sensor, logical camera, monocular camera, depth camera, LIDAR, magnetometer, altimeter, and IMU is available through [Gazebo Sensors](/libs/sensors) and [Gazebo Sim](/libs/gazebo).
+5. [Launch system](/libs/launch) capable of running and managing a set of plugins and executables.
+6. Cloud-hosted simulation assets provided by [app.gazebosim.org](https://app.gazebosim.org).
+7. Distributed simulation using lock-stepping.
+8. Dynamic loading/unloading of simulation models based on the location of performer, usually a robot.
+9. Simulation state logging.
+10. Plugin-based GUI system based on [QtQuick](https://en.wikipedia.org/wiki/Qt_Quick) and [Material Design](https://material.io/design/). Available
+    plugins include 3D scene viewer, image viewer, topic echo, topic
+    publisher, world control, and world statistics.
+
+The Acropolis collection is composed by many different Gazebo libraries. The
+collection assures that all libraries all compatible and can be used together.
 
 | Library name       | Version       | Changelog     |
 | ------------------ |:-------------:|:-------------:|
 |   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
-|   gz-common       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common4/Changelog.md)    |
-|   gz-fuel-tools   |       6.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools6/Changelog.md)    |
-|   gz-sim          |       5.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo5/Changelog.md)     |
-|   gz-gui          |       5.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui5/Changelog.md)       |
-|   gz-launch       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch4/Changelog.md)
-|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
-|   gz-msgs         |       7.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs7/Changelog.md)
-|   gz-physics      |       4.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics4/Changelog.md)
+|   gz-common       |       3.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common3/Changelog.md)    |
+|   gz-fuel-tools   |       3.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools3/Changelog.md)    |
+|   gz-sim          |       1.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo1/Changelog.md)     |
+|   gz-gui          |       1.x     |       None       |
+|   gz-launch       |       0.x     |       None       |
+|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)     |
+|   gz-msgs         |       3.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs3/Changelog.md)     |
+|   gz-physics      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics1/Changelog.md)      |
 |   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
-|   gz-rendering    |       5.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering5/Changelog.md)      |
-|   gz-sensors      |       5.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors5/Changelog.md)      |
-|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
-|   gz-transport    |      10.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport10/Changelog.md)      |
-|   gz-utils        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-utils/blob/ign-utils1/Changelog.md)      |
-|   sdformat         |      11.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf11/Changelog.md)        |
-
-## Fortress
-
-1. [Headless simulation using EGL.](https://github.com/gazebosim/gz-rendering/issues/223)
-1. [Refactor ECM::Each for performance.](https://github.com/gazebosim/gz-sim/issues/711)
-1. [Upgrade to Ogre 2.2.](https://github.com/gazebosim/gz-rendering/issues/223)
-1. [Improve `<pose>` tag on SDFormat.](https://github.com/osrf/sdformat/issues/252)
-1. [Heightmaps on Ogre 2](https://github.com/gazebosim/gz-rendering/issues/187)
-1. [Spherical coordinates](https://github.com/gazebosim/gz-sim/issues/981)
-1. [Buoyancy engine](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/examples/worlds/buoyancy_engine.sdf)
-1. [Control lights from ROS 2](https://github.com/gazebosim/ros_gz/pull/187)
-1. [Python interface to Gazebo.](https://github.com/gazebosim/gz-sim/issues/789)
-1. [Custom shaders.](https://github.com/gazebosim/gz-sim/issues/657)
-1. [Visual plugins.](https://github.com/gazebosim/gz-sim/issues/265)
-1. [Rendering waves.](https://github.com/gazebosim/gz-rendering/pull/541)
-1. [Generic comms system.](https://github.com/gazebosim/gz-sim/pull/1416)
-1. [Wheel slip commands.](https://github.com/gazebosim/gz-sim/pull/1241)
-1. [USD importer / exporter.](https://github.com/gazebosim/sdformat/tree/sdf12/examples/usdConverter)
-1. [Bridge Gazebo services to ROS 2 services.](https://github.com/gazebosim/ros_ign/pull/211)
-1. [Omniverse application](https://github.com/gazebosim/gz-omni)
-1. [Pose and Twist with covariance.](https://github.com/gazebosim/gz-msgs/pull/224)
-1. Sensors
-  1. [Custom sensors.](https://gazebosim.org/api/sensors/6.0/custom_sensors.html)
-  1. [Segmentation camera.](https://gazebosim.org/api/sensors/6.0/segmentationcamera_igngazebo.html)
-  1. [Joint force-torque sensor.](https://github.com/gazebosim/gz-sensors/issues/25)
-  1. [GPS / NavSat sensor.](https://github.com/gazebosim/gz-sensors/issues/23)
-  1. [Triggered cameras.](https://github.com/gazebosim/gz-sensors/issues/185)
-1. GUI features
-    1. [Consolidate Scene3D with GzScene3D](https://github.com/gazebosim/gz-gui/issues/137)
-    1. [Visualize wireframes](https://github.com/gazebosim/gz-sim/pull/816)
-    1. [Visualize transparent](https://github.com/gazebosim/gz-sim/pull/878)
-    1. [Visualize inertia](https://github.com/gazebosim/gz-sim/issues/111)
-    1. [Visualize center of mass](https://github.com/gazebosim/gz-sim/issues/110)
-    1. [Visualize joints](https://github.com/gazebosim/gz-sim/issues/106)
-    1. [Orthographic view](https://github.com/gazebosim/gz-sim/issues/103)
-    1. [System inspector.](https://github.com/gazebosim/gz-sim/issues/191)
-
-| Library name       | Version       | Changelog     |
-| ------------------ |:-------------:|:-------------:|
-|   gz-cmake        |       2.x     |       [Changelog](https://github.com/gazebosim/gz-cmake/blob/ign-cmake2/Changelog.md)     |
-|   gz-common       |       4.x     |       [Changelog](https://github.com/gazebosim/gz-common/blob/ign-common4/Changelog.md)    |
-|   gz-fuel-tools   |       7.x     |       [Changelog](https://github.com/gazebosim/gz-fuel-tools/blob/ign-fuel-tools7/Changelog.md)    |
-|   gz-sim          |       6.x     |       [Changelog](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/Changelog.md)     |
-|   gz-gui          |       6.x     |       [Changelog](https://github.com/gazebosim/gz-gui/blob/ign-gui6/Changelog.md)       |
-|   gz-launch       |       5.x     |       [Changelog](https://github.com/gazebosim/gz-launch/blob/ign-launch5/Changelog.md)
-|   gz-math         |       6.x     |       [Changelog](https://github.com/gazebosim/gz-math/blob/ign-math6/Changelog.md)
-|   gz-msgs         |       8.x     |       [Changelog](https://github.com/gazebosim/gz-msgs/blob/ign-msgs8/Changelog.md)
-|   gz-physics      |       5.x     |       [Changelog](https://github.com/gazebosim/gz-physics/blob/ign-physics5/Changelog.md)
-|   gz-plugin       |       1.x     |       [Changelog](https://github.com/gazebosim/gz-plugin/blob/ign-plugin1/Changelog.md)     |
-|   gz-rendering    |       6.x     |       [Changelog](https://github.com/gazebosim/gz-rendering/blob/ign-rendering6/Changelog.md)      |
-|   gz-sensors      |       6.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors6/Changelog.md)      |
-|   gz-tools        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools1/Changelog.md)     |
-|   gz-transport    |      11.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport11/Changelog.md)      |
-|   gz-utils        |       1.x     |       [Changelog](https://github.com/gazebosim/gz-utils/blob/ign-utils1/Changelog.md)      |
-|   sdformat         |      12.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf12/Changelog.md)        |
-
-
+|   gz-rendering    |       1.x     |       None      |
+|   gz-sensors      |       1.x     |       [Changelog](https://github.com/gazebosim/gz-sensors/blob/ign-sensors1/Changelog.md)      |
+|   gz-tools        |       0.x     |       [Changelog](https://github.com/gazebosim/gz-tools/blob/ign-tools0/Changelog.md)     |
+|   gz-transport    |       6.x     |       [Changelog](https://github.com/gazebosim/gz-transport/blob/ign-transport6/Changelog.md)      |
+|   sdformat         |       8.x     |       [Changelog](https://github.com/osrf/sdformat/blob/sdf8/Changelog.md)        |


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🎉 New feature

## Summary

Adds a `Development` section to the main `index.yaml` file. Reverses the chronological order of the `release-features`, and fixed a rendering bug in one of the headers.

## Test it

Try it on https://staging.gazebosim.org.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.