### PR TITLE
Add migration from Ignition page to index

### DIFF
--- a/garden/index.yaml
+++ b/garden/index.yaml
@@ -29,6 +29,9 @@ pages:
       - name: install_windows_src
         title: Windows Source Install
         file: install_windows_src.md
+      - name: migration_from_ignition
+        title: Migration from Ignition
+        file: migration_from_ignition.md
       - name: troubleshooting
         title: Troubleshooting
         file: troubleshooting.md


### PR DESCRIPTION
The new page added in #275 needs to be added to the index.

The link on this page is broken:

https://gazebosim.org/docs/garden/install