### PR TITLE
Fix nightly build

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -12,12 +12,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup S3 cmd
+    - name: Setup aws cli
       run: |
         sudo apt-get update &&
-        sudo apt-get install s3cmd awscli &&
-        s3cmd --configure --access_key=${{ secrets.AWS_ACCESS_KEY_ID }} --secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }} --no-encrypt --dump-config > $HOME/.s3cfg &&
-        ls $HOME/.s3cfg
+        sudo apt-get install awscli
     - name: Run nightly upload
       run: cd tools && bash build_docs.sh all
       env:

--- a/tools/Dockerfile.acropolis
+++ b/tools/Dockerfile.acropolis
@@ -7,11 +7,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.blueprint
+++ b/tools/Dockerfile.blueprint
@@ -9,11 +9,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.citadel
+++ b/tools/Dockerfile.citadel
@@ -11,11 +11,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.dome
+++ b/tools/Dockerfile.dome
@@ -11,11 +11,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.edifice
+++ b/tools/Dockerfile.edifice
@@ -11,11 +11,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.fortress
+++ b/tools/Dockerfile.fortress
@@ -11,11 +11,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/Dockerfile.garden
+++ b/tools/Dockerfile.garden
@@ -11,11 +11,11 @@ RUN apt-get update \
 
 ARG GZ_VERSION_PASSWORD
 ARG GZ_VERSION_DATE
-ARG AWS_ACCESS_KEY
-ARG AWS_SECRET_KEY
+ARG AWS_ACCESS_KEY_ID
+ARG AWS_SECRET_ACCESS_KEY
 
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
-RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY $AWS_SECRET_KEY
+RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
 COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
 RUN scripts/enable_gcc8.sh

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -2,8 +2,8 @@
 #
 # Usage
 #   1. Export the AWS keys using:
-#           export AWS_ACCESS_KEY=aws_access_key_value
-#           export AWS_SECRET_KEY=aws_secret_key_value
+#           export AWS_ACCESS_KEY_ID=aws_access_key_value
+#           export AWS_SECRET_ACCESS_KEY=aws_secret_key_value
 #   2. Documentation upload requires a password to
 #      https://api.gazebosim.org. The password is listed on the
 #      internal Open Robotics wiki. Set the GZ_VERSION_PASSWORD environment
@@ -28,37 +28,37 @@
 # library documentation, and we want to guarantee a clean system.
 if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Acropolis\e[0m\e[39m"
-  docker build -t gz-acropolis-docs -f Dockerfile.acropolis --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-acropolis-docs -f Dockerfile.acropolis --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Blueprint\e[0m\e[39m"
-  docker build -t gz-blueprint-docs -f Dockerfile.blueprint --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-blueprint-docs -f Dockerfile.blueprint --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
-  docker build -t gz-citadel-docs -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-citadel-docs -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'dome' || $1 == 'Dome' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Dome\e[0m\e[39m"
-  docker build -t gz-dome-docs -f Dockerfile.dome --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-dome-docs -f Dockerfile.dome --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'edifice' || $1 == 'Edifice' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Edifice\e[0m\e[39m"
-  docker build -t gz-edifice-docs -f Dockerfile.edifice --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-edifice-docs -f Dockerfile.edifice --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'all' || $1 == 'fortress' || $1 == 'Fortress' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Fortress\e[0m\e[39m"
-  docker build -t gz-fortress-docs -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-fortress-docs -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'all' || $1 == 'garden' || $1 == 'Garden' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Garden\e[0m\e[39m"
-  docker build -t gz-garden-docs -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY --build-arg AWS_SECRET_KEY .
+  docker build -t gz-garden-docs -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 


### PR DESCRIPTION
Signed-off-by: Nate Koenig <nate@openrobotics.org>

# 🦟 Bug fix

## Summary

The nightly github action used differnent environment variable names for the AWS credentials. This PR changes the build scripts to match.

Also needed is: https://github.com/gazebosim/gz-cmake/pull/308

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.