### PR TITLE
Update comparison for Gazebo Classic vs Garden

### DIFF
--- a/garden/comparison.md
+++ b/garden/comparison.md
@@ -280,8 +280,10 @@ ROS integration through the
 
 Supported versions:
 
-* ROS 1 Melodic (from source) / Noetic (from source)
-* ROS 2 Galactic (from source) / Humble (binaries)
+* ROS 1 Noetic (from source)
+* ROS 2 Humble (from source) / Rolling (from source)
+
+Note: binaries for ROS2 might be available sometime after the Garden release.
 
 ## Platforms
 

--- a/garden/comparison.md
+++ b/garden/comparison.md
@@ -32,7 +32,7 @@ Segmentation camera | ✕ | ✓
 Sonar | ✓ | [Issue](https://github.com/gazebosim/gz-sensors/issues/19)
 Thermal camera | ✕  | ✓
 Triggered camera | ✕ | ✓
-Wide-angle camera | ✓ | ✕ (available from Garden)
+Wide-angle camera | ✓ | ([ogre 1.x only](https://github.com/gazebosim/gz-sensors/issues/24))
 Wireless | ✓ | [Issue](https://github.com/gazebosim/gz-sensors/issues/28)
 
 Sensor features | Gazebo-classic | Gazebo Sim
@@ -57,7 +57,7 @@ Populations | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/240)
 Actors | ✓ | ✓
 Markers | ✓ | ✓
 Heightmaps | ✓ | ✓
-DEM (Digital Elevation Models) | ✓ | ✕ (available from Garden)
+DEM (Digital Elevation Models) | ✓ | ✓
 Polylines | ✓ | ✓
 World plugins | ✓ | ✓ Now called System plugin
 Model plugins | ✓ | ✓ Now called System plugin
@@ -81,7 +81,7 @@ BuoyancyPlugin | ✓ | [✓](https://github.com/gazebosim/gz-sim/blob/ign-gazebo
 CartDemoPlugin | ✓ | ✕
 CessnaPlugin | ✓ |
 DiffDrivePlugin | ✓ | ✓
-ElevatorPlugin | ✓ |
+ElevatorPlugin | ✓ | ✓
 FlashLightPlugin | ✓ |
 FollowerPlugin | ✓ |
 GimbalSmall2dPlugin | ✓ |

--- a/garden/comparison.md
+++ b/garden/comparison.md
@@ -22,9 +22,11 @@ Force-torque | ✓ | ✓
 GPS / NavSat | ✓ |  ✓
 GPU Ray | ✓ | ✓ Renamed to GPU Lidar
 IMU | ✓ | ✓
+Logical audio sensor | ✕ | ✓
 Logical camera | ✓ | ✓
-Magnetometer | ✓ | ✓
+Magnetometer | ✕ | ✓
 Multi-camera | ✓ | ✕  Use individual cameras with same update rate
+Optical tactile sensor | ✕ | ✓
 Ray | ✓ | [Issue](https://github.com/gazebosim/gz-sensors/issues/26)
 RFID sensor and tag | ✓ | [Issue](https://github.com/gazebosim/gz-sensors/issues/27)
 RGBD camera | ✕ | ✓
@@ -72,6 +74,7 @@ System plugins | ✓ | ✓ Through Gazebo Launch
 
 Plugin | Gazebo-classic | Gazebo Sim
 -- | -- | --
+AckermannSteering | ✕ | ✓
 ActorPlugin | ✓ | ✕ See [FollowActor](https://github.com/gazebosim/gz-sim/blob/main/src/systems/follow_actor/FollowActor.hh) for a demo of Actor APIs
 ActuatorPlugin | ✓ |
 ArduCopterPlugin | ✓ |
@@ -79,7 +82,8 @@ AttachLightPlugin | ✓ | ✕ Does not apply, use SDF
 Breadcrumbs | ✕ | ✓
 BuoyancyPlugin | ✓ | [✓](https://github.com/gazebosim/gz-sim/blob/ign-gazebo6/examples/worlds/buoyancy.sdf)
 CartDemoPlugin | ✓ | ✕
-CessnaPlugin | ✓ |
+CessnaPlugin | ✓ | ✕
+DetachableJoint | ✕ | ✓
 DiffDrivePlugin | ✓ | ✓
 ElevatorPlugin | ✓ | ✓
 FlashLightPlugin | ✓ |
@@ -91,7 +95,7 @@ HydraDemoPlugin | ✓ |
 InitialVelocityPlugin | ✓ | ✓ (use VelocityControl or JointController)
 JointControlPlugin | ✓ (force / pos / vel, from SDF) | ✓ (vel, from msg)
 JointStatePublisher | ✕ | ✓
-JointTrajectoryPlugin | ✓ |
+JointTrajectoryPlugin | ✓ | ✓
 KeysToCmdVelPlugin | ✓ | Use `gz::gui::KeyPublisher` with `gz::gazebo::systems::TriggeredPublisher`
 KeysToJointsPlugin | ✓ | Use `gz::gui::KeyPublisher` with `gz::gazebo::systems::TriggeredPublisher`
 LedPlugin | ✓ |
@@ -99,8 +103,10 @@ LiftDragPlugin | ✓ | ✓
 LinearBatteryConsumerPlugin | ✓ | ✓
 LinearBatteryPlugin | ✓ | ✓
 LinkPlot3DPlugin | ✓ | ✓ (renamed to Plot3D)
+MecanumDrive | ✕ | ✓
 MudPlugin | ✓ |
 MulticopterMotorModel | ✕ | ✓
+OdometryPublisherPlugin | ✕ | ✓
 PlaneDemoPlugin | ✓ |
 PosePublisher | ✕ | ✓
 RandomVelocityPlugin | ✓ |
@@ -140,10 +146,12 @@ CameraPlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
 ContactPlugin | ✓ | ✓
 DepthCameraPlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
 FiducialCameraPlugin | ✓ |
-ForceTorquePlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
+ForceTorquePlugin | ✓ | ✓
 GpuRayPlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
-ImuSensorPlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
+ImuSensorPlugin | ✓ | ✓
 LensFlareSensorPlugin | ✓ |
+MagnetometerPlugin | ✕ | ✓
+OpticalTactilePlugin | ✕ | ✓
 PressurePlugin | ✓ |
 RayPlugin | ✓ | [Issue](https://github.com/gazebosim/gz-sim/issues/49)
 RaySensorNoisePlugin | ✓ | ✕ Use SDF
@@ -171,6 +179,7 @@ TimerGUIPlugin | ✓ |
 
 Plugin | Gazebo-classic | Gazebo Sim
 -- | -- | --
+ColladaWorldExporter | ✕ | ✓
 ModelPropShop | ✓ | [✓](https://gazebosim.org/api/gazebo/5.4/model_photo_shoot.html)
 RestUiPlugin | ✓ |
 RestWebPlugin | ✓ |


### PR DESCRIPTION
Update for the comparison between Garden and Gazebo Classic. Fixes https://github.com/gazebosim/garden-tutorial-party/issues/1945 https://github.com/gazebosim/garden-tutorial-party/issues/1946 https://github.com/gazebosim/garden-tutorial-party/issues/1947 https://github.com/gazebosim/garden-tutorial-party/issues/1948 https://github.com/gazebosim/garden-tutorial-party/issues/1949 https://github.com/gazebosim/garden-tutorial-party/issues/1950 https://github.com/gazebosim/garden-tutorial-party/issues/1951 https://github.com/gazebosim/garden-tutorial-party/issues/1952

- Updates of features expected for Garden
- Added missing plugins from src/systems in gz-sim
- Update ROS2 platforms
