### PR TITLE
Hotkeys: Corrected Ctrl+q hotkey description

### DIFF
--- a/garden/hotkeys.md
+++ b/garden/hotkeys.md
@@ -28,9 +28,9 @@
 
   <tr><td>Constrain along axis</td><td>x/y/z</td><td>hold key while manipulating a model to constrain movement along that axis</td></tr>
 
-  <tr><td>Snap when rotating</td><td>Ctrl + drag</td><td>hold Ctrl while rotating a model to rotate in customizable increments (default 45°)</td></tr>
+  <tr><td>Snap when rotating</td><td>Ctrl + drag</td><td>hold Ctrl while rotating a model to rotate in customizable increments (default is 45° but can be changed from Tranform Control GUI)</td></tr>
 
-  <tr><td>Snap when translating</td><td>Ctrl + drag</td><td>hold Ctrl while translating a model to move in customizable increments (default 1m)</td></tr>
+  <tr><td>Snap when translating</td><td>Ctrl + drag</td><td>hold Ctrl while translating a model to move in customizable increments (default is 1m but can be changed from Tranform Control GUI)</td></tr>
 
   <tr><td>Align to world frame</td><td>Shift</td><td>hold Shift while manipulating a model to temporarily align axis its to the world frame</td></tr>
 
@@ -42,7 +42,7 @@
 
   <tr><td>Load Config</td><td>Ctrl + o</td><td>hold Ctrl and press "o" to load a window configuration</td></tr>
 
-  <tr><td>Close</td><td>Ctrl + q</td><td>hold Ctrl and press "o" to shut down Gazebo</td></tr>
+  <tr><td>Close</td><td>Ctrl + q</td><td>hold Ctrl and press "q" to shut down Gazebo</td></tr>
 
   <tr><td>Search Menu</td><td>/</td><td>press "/" to open the search menu for plugins</td></tr>
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/garden-tutorial-party/issues/1964

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->
This PR corrects the description of the `Ctrl + q` shortcut as it showed the wrong key. Apart from that, there are just some minor additions.