### PR TITLE
Fixed some typos and deprecations in tutorials

### DIFF
--- a/garden/building_robot.md
+++ b/garden/building_robot.md
@@ -21,15 +21,15 @@ We will start by building a simple world and then build our robot in it. Open a 
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="libgz-sim-physics-system.so"
+            filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="libgz-sim-user-commands-system.so"
+            filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="libgz-sim-scene-broadcaster-system.so"
+            filename="gz-sim-scene-broadcaster-system"
             name="gz::sim::systems::SceneBroadcaster">
         </plugin>
 

--- a/garden/moving_robot.md
+++ b/garden/moving_robot.md
@@ -160,7 +160,7 @@ Map each arrow (key stroke) with the desired message (movement) as we did with t
 * Left &#10142; 16777234 &#10142; linear: {x: 0.0}, angular: {z: 0.5}
 * Up &#10142; 16777235 &#10142; linear: {x: 0.5}, angular: {z: 0.0}
 * Right &#10142; 16777236 &#10142; linear: {x: 0.0}, angular: {z: -0.5}
-* Down &#10142; 16777237 &#10142; linear: {x: 0.5}, angular: {z: 0.0}
+* Down &#10142; 16777237 &#10142; linear: {x: -0.5}, angular: {z: 0.0}
 
 Now it's your turn try to make the robot move using different keys.
 

--- a/garden/moving_robot.md
+++ b/garden/moving_robot.md
@@ -18,7 +18,7 @@ model tags.
 
 ```xml
 <plugin
-    filename="libgz-sim-diff-drive-system.so"
+    filename="gz-sim-diff-drive-system"
     name="gz::sim::systems::DiffDrive">
     <left_joint>left_wheel_joint</left_joint>
     <right_joint>right_wheel_joint</right_joint>
@@ -100,7 +100,7 @@ Let's add the following code under the `<world>` tag:
 
 ```xml
 <!-- Moving Forward-->
-<plugin filename="libgz-sim-triggered-publisher-system.so"
+<plugin filename="gz-sim-triggered-publisher-system"
         name="gz::sim::systems::TriggeredPublisher">
     <input type="gz.msgs.Int32" topic="/keyboard/keypress">
         <match field="data">16777235</match>
@@ -144,7 +144,7 @@ For example, the Down arrow:
 
 ```xml
 <!-- Moving Backward-->
-<plugin filename="libgz-sim-triggered-publisher-system.so"
+<plugin filename="gz-sim-triggered-publisher-system"
         name="gz::sim::systems::TriggeredPublisher">
     <input type="gz.msgs.Int32" topic="/keyboard/keypress">
         <match field="data">16777237</match>

--- a/garden/sdf_worlds.md
+++ b/garden/sdf_worlds.md
@@ -38,7 +38,7 @@ Plugins are a dynamically loaded chunk of code. For example:
 
 ```xml
 <plugin
-    filename="libgz-sim-physics-system.so"
+    filename="gz-sim-physics-system"
     name="gz::sim::systems::Physics">
 </plugin>
 ```
@@ -47,7 +47,7 @@ The `Physics` plugin is very important for simulating the dynamics of the world.
 
 ```xml
 <plugin
-    filename="libgz-sim-user-commands-system.so"
+    filename="gz-sim-user-commands-system"
     name="gz::sim::systems::UserCommands">
 </plugin>
 ```
@@ -56,7 +56,7 @@ The `UserCommands` plugin is responsible for creating models, moving models, del
 
 ```xml
 <plugin
-    filename="libgz-sim-scene-broadcaster-system.so"
+    filename="gz-sim-scene-broadcaster-system"
     name="gz::sim::systems::SceneBroadcaster">
 </plugin>
 ```

--- a/garden/sensors.md
+++ b/garden/sensors.md
@@ -80,7 +80,6 @@ obstacle as follows:
     <static>true</static>
     <pose>5 0 0 0 0 0</pose><!--pose relative to the world-->
     <link name='box'>
-        <pose/>
         <visual name='visual'>
             <geometry>
                 <box>

--- a/garden/sensors.md
+++ b/garden/sensors.md
@@ -20,7 +20,7 @@ and the `linear_acceleration` in the three axes. Let's use our
 To define the `IMU` sensor add this code under the `<world>` tag:
 
 ```xml
-<plugin filename="libgz-sim-imu-system.so"
+<plugin filename="gz-sim-imu-system"
         name="gz::sim::systems::Imu">
 </plugin>
 ```
@@ -113,7 +113,7 @@ Now run the world and make sure that the wall appears in the simulation like thi
 Let's add the contact sensor to the wall. As with the `IMU` sensor, we should first define the `Contact` sensor by adding the following code:
 
 ```xml
-<plugin filename="libgz-sim-contact-system.so"
+<plugin filename="gz-sim-contact-system"
         name="gz::sim::systems::Contact">
 </plugin>
 ```
@@ -133,7 +133,7 @@ The definition of the `<sensor>` is straight forward, we just define the `name` 
 We need also to add the `TouchPlugin` under the `wall` model as follows:
 
 ```xml
-<plugin filename="libgz-sim-touchplugin-system.so"
+<plugin filename="gz-sim-touchplugin-system"
         name="gz::sim::systems::TouchPlugin">
     <target>vehicle_blue</target>
     <namespace>wall</namespace>
@@ -163,7 +163,7 @@ When you hit the bump you should see a message `data: true` on the terminal wher
 Now we can use the `TriggeredPublisher` plugin to make our robot stop when hits the wall as follows:
 
 ```xml
-<plugin filename="libgz-sim-triggered-publisher-system.so"
+<plugin filename="gz-sim-triggered-publisher-system"
         name="gz::sim::systems::TriggeredPublisher">
     <input type="gz.msgs.Boolean" topic="/wall/touched">
         <match>data: true</match>
@@ -195,7 +195,7 @@ Then add this plugin under the `<world>` tag, to be able to use the `lidar` sens
 
 ```xml
     <plugin
-      filename="libgz-sim-sensors-system.so"
+      filename="gz-sim-sensors-system"
       name="gz::sim::systems::Sensors">
       <render_engine>ogre2</render_engine>
     </plugin>

--- a/garden/tutorials/building_robot/building_robot.sdf
+++ b/garden/tutorials/building_robot/building_robot.sdf
@@ -6,16 +6,16 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="ignition-gazebo-physics-system"
-            name="ignition::gazebo::systems::Physics">
+            filename="libgz-sim-physics-system.so"
+            name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="ignition-gazebo-user-commands-system"
-            name="ignition::gazebo::systems::UserCommands">
+            filename="libgz-sim-user-commands-system.so"
+            name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="ignition-gazebo-scene-broadcaster-system"
-            name="ignition::gazebo::systems::SceneBroadcaster">
+            filename="libgz-sim-scene-broadcaster-system.so"
+            name="gz::sim::systems::SceneBroadcaster">
         </plugin>
 
         <light type="directional" name="sun">

--- a/garden/tutorials/building_robot/building_robot.sdf
+++ b/garden/tutorials/building_robot/building_robot.sdf
@@ -6,15 +6,15 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="libgz-sim-physics-system.so"
+            filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="libgz-sim-user-commands-system.so"
+            filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="libgz-sim-scene-broadcaster-system.so"
+            filename="gz-sim-scene-broadcaster-system"
             name="gz::sim::systems::SceneBroadcaster">
         </plugin>
 

--- a/garden/tutorials/moving_robot/moving_robot.sdf
+++ b/garden/tutorials/moving_robot/moving_robot.sdf
@@ -6,15 +6,15 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="libgz-sim-physics-system.so"
+            filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="libgz-sim-user-commands-system.so"
+            filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="libgz-sim-scene-broadcaster-system.so"
+            filename="gz-sim-scene-broadcaster-system"
             name="gz::sim::systems::SceneBroadcaster">
         </plugin>
 
@@ -245,7 +245,7 @@
 
             <!--diff drive plugin-->
             <plugin
-                filename="libgz-sim-diff-drive-system.so"
+                filename="gz-sim-diff-drive-system"
                 name="gz::sim::systems::DiffDrive">
                 <left_joint>left_wheel_joint</left_joint>
                 <right_joint>right_wheel_joint</right_joint>
@@ -257,7 +257,7 @@
         </model>
 
         <!-- Moving Left-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777234</match>
@@ -267,7 +267,7 @@
             </output>
         </plugin>
         <!-- Moving Forward-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777235</match>
@@ -277,7 +277,7 @@
             </output>
         </plugin>
         <!-- Moving Right-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777236</match>
@@ -287,7 +287,7 @@
             </output>
         </plugin>
         <!-- Moving Backward-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777237</match>

--- a/garden/tutorials/moving_robot/moving_robot.sdf
+++ b/garden/tutorials/moving_robot/moving_robot.sdf
@@ -6,16 +6,16 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="libignition-gazebo-physics-system.so"
-            name="ignition::gazebo::systems::Physics">
+            filename="libgz-sim-physics-system.so"
+            name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="libignition-gazebo-user-commands-system.so"
-            name="ignition::gazebo::systems::UserCommands">
+            filename="libgz-sim-user-commands-system.so"
+            name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="libignition-gazebo-scene-broadcaster-system.so"
-            name="ignition::gazebo::systems::SceneBroadcaster">
+            filename="libgz-sim-scene-broadcaster-system.so"
+            name="gz::sim::systems::SceneBroadcaster">
         </plugin>
 
         <light type="directional" name="sun">
@@ -245,8 +245,8 @@
 
             <!--diff drive plugin-->
             <plugin
-                filename="libignition-gazebo-diff-drive-system.so"
-                name="ignition::gazebo::systems::DiffDrive">
+                filename="libgz-sim-diff-drive-system.so"
+                name="gz::sim::systems::DiffDrive">
                 <left_joint>left_wheel_joint</left_joint>
                 <right_joint>right_wheel_joint</right_joint>
                 <wheel_separation>1.2</wheel_separation>
@@ -256,47 +256,44 @@
             </plugin>
         </model>
 
+        <!-- Moving Left-->
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
+                <match field="data">16777234</match>
+            </input>
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
+                linear: {x: 0.0}, angular: {z: 0.5}
+            </output>
+        </plugin>
         <!-- Moving Forward-->
-        <plugin filename="libignition-gazebo-triggered-publisher-system.so"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777235</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
                 linear: {x: 0.5}, angular: {z: 0.0}
             </output>
         </plugin>
-
-        <!-- Moving Backward-->
-        <plugin filename="libignition-gazebo-triggered-publisher-system.so"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
-                <match field="data">16777237</match>
-            </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
-                linear: {x: -0.5}, angular: {z: 0.0}
-            </output>
-        </plugin>
-
-        <!-- Rotating right-->
-        <plugin filename="libignition-gazebo-triggered-publisher-system.so"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
+        <!-- Moving Right-->
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777236</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
                 linear: {x: 0.0}, angular: {z: -0.5}
             </output>
         </plugin>
-
-        <!--Rotating left-->
-        <plugin filename="libignition-gazebo-triggered-publisher-system.so"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
-                <match field="data">16777234</match>
+        <!-- Moving Backward-->
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
+                <match field="data">16777237</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
-                linear: {x: 0.0}, angular: {z: 0.5}
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
+                linear: {x: -0.5}, angular: {z: 0.0}
             </output>
         </plugin>
     </world>

--- a/garden/tutorials/sdf_worlds/world_demo.sdf
+++ b/garden/tutorials/sdf_worlds/world_demo.sdf
@@ -6,15 +6,15 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin
-      filename="libgz-sim-physics-system.so"
+      filename="gz-sim-physics-system"
       name="gz::sim::systems::Physics">
     </plugin>
     <plugin
-      filename="libgz-sim-user-commands-system.so"
+      filename="gz-sim-user-commands-system"
       name="gz::sim::systems::UserCommands">
     </plugin>
     <plugin
-      filename="libgz-sim-scene-broadcaster-system.so"
+      filename="gz-sim-scene-broadcaster-system"
       name="gz::sim::systems::SceneBroadcaster">
     </plugin>
 

--- a/garden/tutorials/sdf_worlds/world_demo.sdf
+++ b/garden/tutorials/sdf_worlds/world_demo.sdf
@@ -6,27 +6,27 @@
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin
-      filename="libignition-gazebo-physics-system.so"
-      name="ignition::gazebo::systems::Physics">
+      filename="libgz-sim-physics-system.so"
+      name="gz::sim::systems::Physics">
     </plugin>
     <plugin
-      filename="libignition-gazebo-user-commands-system.so"
-      name="ignition::gazebo::systems::UserCommands">
+      filename="libgz-sim-user-commands-system.so"
+      name="gz::sim::systems::UserCommands">
     </plugin>
     <plugin
-      filename="libignition-gazebo-scene-broadcaster-system.so"
-      name="ignition::gazebo::systems::SceneBroadcaster">
+      filename="libgz-sim-scene-broadcaster-system.so"
+      name="gz::sim::systems::SceneBroadcaster">
     </plugin>
 
     <gui fullscreen="0">
 
       <!-- 3D scene -->
       <plugin filename="GzScene3D" name="3D View">
-        <ignition-gui>
+        <gz-gui>
           <title>3D View</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="string" key="state">docked</property>
-        </ignition-gui>
+        </gz-gui>
 
         <engine>ogre2</engine>
         <scene>scene</scene>
@@ -37,7 +37,7 @@
 
       <!-- World control -->
       <plugin filename="WorldControl" name="World control">
-        <ignition-gui>
+        <gz-gui>
           <title>World control</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -50,7 +50,7 @@
             <line own="left" target="left"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <play_pause>true</play_pause>
         <step>true</step>
@@ -62,7 +62,7 @@
 
       <!-- World statistics -->
       <plugin filename="WorldStats" name="World stats">
-        <ignition-gui>
+        <gz-gui>
           <title>World stats</title>
           <property type="bool" key="showTitleBar">false</property>
           <property type="bool" key="resizable">false</property>
@@ -75,7 +75,7 @@
             <line own="right" target="right"/>
             <line own="bottom" target="bottom"/>
           </anchors>
-        </ignition-gui>
+        </gz-gui>
 
         <sim_time>true</sim_time>
         <real_time>true</real_time>

--- a/garden/tutorials/sensors/sensor_tutorial.sdf
+++ b/garden/tutorials/sensors/sensor_tutorial.sdf
@@ -6,36 +6,39 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="ignition-gazebo-physics-system"
-            name="ignition::gazebo::systems::Physics">
+            filename="libgz-sim-physics-system.so"
+            name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="ignition-gazebo-user-commands-system"
-            name="ignition::gazebo::systems::UserCommands">
+            filename="libgz-sim-user-commands-system.so"
+            name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="ignition-gazebo-scene-broadcaster-system"
-            name="ignition::gazebo::systems::SceneBroadcaster">
+            filename="libgz-sim-scene-broadcaster-system.so"
+            name="gz::sim::systems::SceneBroadcaster">
         </plugin>
-        <plugin filename="ignition-gazebo-imu-system"
-                name="ignition::gazebo::systems::Imu">
+        <plugin
+            filename="libgz-sim-imu-system.so"
+            name="gz::sim::systems::Imu">
         </plugin>
-        <plugin filename="ignition-gazebo-sensors-system"
-                name="ignition::gazebo::systems::Sensors">
+        <plugin
+            filename="libgz-sim-sensors-system.so"
+            name="gz::sim::systems::Sensors">
             <render_engine>ogre2</render_engine>
         </plugin>
-        <plugin filename="ignition-gazebo-contact-system"
-                name="ignition::gazebo::systems::Contact">
+        <plugin 
+            filename="libgz-sim-contact-system.so"
+            name="gz::sim::systems::Contact">
         </plugin>
         <gui fullscreen="0">
 
             <!-- 3D scene -->
             <plugin filename="GzScene3D" name="3D View">
-                <ignition-gui>
-                <title>3D View</title>
-                <property type="bool" key="showTitleBar">false</property>
-                <property type="string" key="state">docked</property>
-                </ignition-gui>
+                <gz-gui>
+                    <title>3D View</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="string" key="state">docked</property>
+                </gz-gui>
 
                 <engine>ogre2</engine>
                 <scene>scene</scene>
@@ -45,20 +48,20 @@
 
             <!-- World control -->
             <plugin filename="WorldControl" name="World control">
-                <ignition-gui>
-                <title>World control</title>
-                <property type="bool" key="showTitleBar">false</property>
-                <property type="bool" key="resizable">false</property>
-                <property type="double" key="height">72</property>
-                <property type="double" key="width">121</property>
-                <property type="double" key="z">1</property>
+                <gz-gui>
+                    <title>World control</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="bool" key="resizable">false</property>
+                    <property type="double" key="height">72</property>
+                    <property type="double" key="width">121</property>
+                    <property type="double" key="z">1</property>
 
-                <property type="string" key="state">floating</property>
-                <anchors target="3D View">
-                    <line own="left" target="left"/>
-                    <line own="bottom" target="bottom"/>
-                </anchors>
-                </ignition-gui>
+                    <property type="string" key="state">floating</property>
+                    <anchors target="3D View">
+                        <line own="left" target="left"/>
+                        <line own="bottom" target="bottom"/>
+                    </anchors>
+                </gz-gui>
 
                 <play_pause>true</play_pause>
                 <step>true</step>
@@ -69,20 +72,20 @@
 
             <!-- World statistics -->
             <plugin filename="WorldStats" name="World stats">
-                <ignition-gui>
-                <title>World stats</title>
-                <property type="bool" key="showTitleBar">false</property>
-                <property type="bool" key="resizable">false</property>
-                <property type="double" key="height">110</property>
-                <property type="double" key="width">290</property>
-                <property type="double" key="z">1</property>
+                <gz-gui>
+                    <title>World stats</title>
+                    <property type="bool" key="showTitleBar">false</property>
+                    <property type="bool" key="resizable">false</property>
+                    <property type="double" key="height">110</property>
+                    <property type="double" key="width">290</property>
+                    <property type="double" key="z">1</property>
 
-                <property type="string" key="state">floating</property>
-                <anchors target="3D View">
-                    <line own="right" target="right"/>
-                    <line own="bottom" target="bottom"/>
-                </anchors>
-                </ignition-gui>
+                    <property type="string" key="state">floating</property>
+                    <anchors target="3D View">
+                        <line own="right" target="right"/>
+                        <line own="bottom" target="bottom"/>
+                    </anchors>
+                </gz-gui>
 
                 <sim_time>true</sim_time>
                 <real_time>true</real_time>
@@ -192,27 +195,27 @@
                     <topic>lidar</topic>
                     <update_rate>10</update_rate>
                     <ray>
-                    <scan>
-                        <horizontal>
-                        <samples>640</samples>
-                        <resolution>1</resolution>
-                        <min_angle>-1.396263</min_angle>
-                        <max_angle>1.396263</max_angle>
-                        </horizontal>
-                        <vertical>
-                        <samples>1</samples>
-                        <resolution>0.01</resolution>
-                        <min_angle>0</min_angle>
-                        <max_angle>0</max_angle>
-                        </vertical>
-                    </scan>
+                        <scan>
+                            <horizontal>
+                            <samples>640</samples>
+                            <resolution>1</resolution>
+                            <min_angle>-1.396263</min_angle>
+                            <max_angle>1.396263</max_angle>
+                            </horizontal>
+                            <vertical>
+                            <samples>1</samples>
+                            <resolution>0.01</resolution>
+                            <min_angle>0</min_angle>
+                            <max_angle>0</max_angle>
+                            </vertical>
+                        </scan>
                     <range>
                         <min>0.08</min>
                         <max>10.0</max>
                         <resolution>0.01</resolution>
                     </range>
                     </ray>
-                    <alwaysOn>1</alwaysOn>
+                    <always_on>1</always_on>
                     <visualize>true</visualize>
                 </sensor>
             </link>
@@ -365,8 +368,8 @@
 
             <!--diff drive plugin-->
             <plugin
-                filename="ignition-gazebo-diff-drive-system"
-                name="ignition::gazebo::systems::DiffDrive">
+                filename="libgz-sim-diff-drive-system.so"
+                name="gz::sim::systems::DiffDrive">
                 <left_joint>left_wheel_joint</left_joint>
                 <right_joint>right_wheel_joint</right_joint>
                 <wheel_separation>1.2</wheel_separation>
@@ -419,8 +422,8 @@
                     </contact>
                 </sensor>
             </link>
-            <plugin filename="ignition-gazebo-touchplugin-system"
-                    name="ignition::gazebo::systems::TouchPlugin">
+            <plugin filename="libgz-sim-touchplugin-system.so"
+                    name="gz::sim::systems::TouchPlugin">
                 <target>vehicle_blue</target>
                 <namespace>wall</namespace>
                 <time>0.001</time>
@@ -428,57 +431,54 @@
             </plugin>
         </model>
 
+        <!-- Moving Left-->
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
+                <match field="data">16777234</match>
+            </input>
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
+                linear: {x: 0.0}, angular: {z: 0.5}
+            </output>
+        </plugin>
         <!-- Moving Forward-->
-        <plugin filename="ignition-gazebo-triggered-publisher-system"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777235</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
                 linear: {x: 0.5}, angular: {z: 0.0}
             </output>
         </plugin>
-
+        <!-- Moving Right-->
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
+                <match field="data">16777236</match>
+            </input>
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
+                linear: {x: 0.0}, angular: {z: -0.5}
+            </output>
+        </plugin>
         <!-- Moving Backward-->
-        <plugin filename="ignition-gazebo-triggered-publisher-system"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777237</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
                 linear: {x: -0.5}, angular: {z: 0.0}
             </output>
         </plugin>
 
-        <!-- Rotating right-->
-        <plugin filename="ignition-gazebo-triggered-publisher-system"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
-                <match field="data">16777236</match>
-            </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
-                linear: {x: 0.0}, angular: {z: -0.5}
-            </output>
-        </plugin>
-
-        <!--Rotating left-->
-        <plugin filename="ignition-gazebo-triggered-publisher-system"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Int32" topic="/keyboard/keypress">
-                <match field="data">16777234</match>
-            </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
-                linear: {x: 0.0}, angular: {z: 0.5}
-            </output>
-        </plugin>
-
         <!--stop when hit the wall-->
-        <plugin filename="ignition-gazebo-triggered-publisher-system"
-                name="ignition::gazebo::systems::TriggeredPublisher">
-            <input type="ignition.msgs.Boolean" topic="/wall/touched">
+        <plugin filename="libgz-sim-triggered-publisher-system.so"
+                name="gz::sim::systems::TriggeredPublisher">
+            <input type="gz.msgs.Boolean" topic="/wall/touched">
                 <match>data: true</match>
             </input>
-            <output type="ignition.msgs.Twist" topic="/cmd_vel">
+            <output type="gz.msgs.Twist" topic="/cmd_vel">
                 linear: {x: 0.0}, angular: {z: 0.0}
             </output>
         </plugin>

--- a/garden/tutorials/sensors/sensor_tutorial.sdf
+++ b/garden/tutorials/sensors/sensor_tutorial.sdf
@@ -6,28 +6,28 @@
             <real_time_factor>1.0</real_time_factor>
         </physics>
         <plugin
-            filename="libgz-sim-physics-system.so"
+            filename="gz-sim-physics-system"
             name="gz::sim::systems::Physics">
         </plugin>
         <plugin
-            filename="libgz-sim-user-commands-system.so"
+            filename="gz-sim-user-commands-system"
             name="gz::sim::systems::UserCommands">
         </plugin>
         <plugin
-            filename="libgz-sim-scene-broadcaster-system.so"
+            filename="gz-sim-scene-broadcaster-system"
             name="gz::sim::systems::SceneBroadcaster">
         </plugin>
         <plugin
-            filename="libgz-sim-imu-system.so"
+            filename="gz-sim-imu-system"
             name="gz::sim::systems::Imu">
         </plugin>
         <plugin
-            filename="libgz-sim-sensors-system.so"
+            filename="gz-sim-sensors-system"
             name="gz::sim::systems::Sensors">
             <render_engine>ogre2</render_engine>
         </plugin>
         <plugin 
-            filename="libgz-sim-contact-system.so"
+            filename="gz-sim-contact-system"
             name="gz::sim::systems::Contact">
         </plugin>
         <gui fullscreen="0">
@@ -368,7 +368,7 @@
 
             <!--diff drive plugin-->
             <plugin
-                filename="libgz-sim-diff-drive-system.so"
+                filename="gz-sim-diff-drive-system"
                 name="gz::sim::systems::DiffDrive">
                 <left_joint>left_wheel_joint</left_joint>
                 <right_joint>right_wheel_joint</right_joint>
@@ -422,7 +422,7 @@
                     </contact>
                 </sensor>
             </link>
-            <plugin filename="libgz-sim-touchplugin-system.so"
+            <plugin filename="gz-sim-touchplugin-system"
                     name="gz::sim::systems::TouchPlugin">
                 <target>vehicle_blue</target>
                 <namespace>wall</namespace>
@@ -432,7 +432,7 @@
         </model>
 
         <!-- Moving Left-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777234</match>
@@ -442,7 +442,7 @@
             </output>
         </plugin>
         <!-- Moving Forward-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777235</match>
@@ -452,7 +452,7 @@
             </output>
         </plugin>
         <!-- Moving Right-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777236</match>
@@ -462,7 +462,7 @@
             </output>
         </plugin>
         <!-- Moving Backward-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Int32" topic="/keyboard/keypress">
                 <match field="data">16777237</match>
@@ -473,7 +473,7 @@
         </plugin>
 
         <!--stop when hit the wall-->
-        <plugin filename="libgz-sim-triggered-publisher-system.so"
+        <plugin filename="gz-sim-triggered-publisher-system"
                 name="gz::sim::systems::TriggeredPublisher">
             <input type="gz.msgs.Boolean" topic="/wall/touched">
                 <match>data: true</match>


### PR DESCRIPTION
# Updated Gazebo tutorials

- Changed `ignition` to `gz` namespace for plugins (so now `.sdf` files correspond to examples from markdown).
- Fixed typos in markdown files (like positive x value for backward movement).