### PR TITLE
Improvements and fixes for releasing instructions

### DIFF
--- a/release.md
+++ b/release.md
@@ -163,7 +163,7 @@ end
 For *prereleases* and *nightly* binaries the versions are a bit special so the
 package manager can handle precedence between all the flavours nicely. There is
 [more information available on this topic for the Gazebo
-libraries](releasing/versioning_pre_nightly.md).
+libraries](releasing/versioning_pre_nightly).
 
 ## Processes triggered when using release.py
 

--- a/release.md
+++ b/release.md
@@ -84,29 +84,6 @@ stability of the software:
      (see [the homebrew-simulation issue](https://github.com/osrf/homebrew-simulation/issues/1314)
      for more information).
 
-### Using the gzdev repository command
-
-The [gzdev repository](https://github.com/gazebo-tooling/gzdev#repository)
-command is a convenient way to configure Ubuntu / Debian systems to use a
-particular set of Gazebo software releases.
-For example, support for prerelease software can be enabled with the following
-command:
-
-`gzdev repository enable osrf prerelease`
-
-The command also has a
-[configuration file](https://github.com/gazebo-tooling/gzdev/blob/master/plugins/config/repository.yaml)
-with repository settings associated with specific packages by name or name
-pattern. For example, the following command will enable the package repositories
-associated with the `gz-cmake3` package:
-
-`gzdev repository enable --project=gz-cmake3`
-
-During the Gazebo Garden development period, this packaage was
-[configured by name](https://github.com/gazebo-tooling/gzdev/blob/7fe5d2c5d758c6b0964e9937d6b82150402d14c2/plugins/config/repository.yaml#L28-L33)
-to use stable and nightly binaries.
-It is customary to use nightly binaries for all unreleased package versions.
-
 ### Metadata for Releasing
 
 All package managers need to define different data fields in order to provide

--- a/release_instructions.md
+++ b/release_instructions.md
@@ -7,7 +7,7 @@ developer's system before triggering the release.  If a permanent operating
 system is used for releasing, these installation steps only need to be
 executed once.
 
-### Software and configurations
+### 1. Software and configurations
 
 > Triggering the releasing process is only supported on Linux at this moment.
 
@@ -36,7 +36,7 @@ export DEBFULLNAME="<Your full name>"
 > **Note:** the two above exported variables can be added to `.bashrc` to have
 > them configured automatically on every run.
 
-### Access and Credentials
+### 2. Access and Credentials
 
 Before starting the release process, make sure to ask for write access to:
 1.  The Gz library intended to be released and
@@ -56,7 +56,7 @@ process:
 
 ## For Each Release
 
-### Team and development checks
+### 1. Team and development checks
 
 When creating a new release, there are some guidelines to follow before starting
 the process:
@@ -68,7 +68,7 @@ the process:
    X the major version of the version bump planned) that could go into the new
    release.
 
-### Update code version and changelogs
+### 2. Update code version and changelogs
 
 The first step to get a new release ready is to update the current code (upstream)
 version (view the [versioning](#versioning) section for more information). This
@@ -120,7 +120,7 @@ document.
   `ignition/gz-fooX_X.Y.Z` where foo is the name of the Gz library and X.Y.Z
   the code version.
 
-### Update packages version
+### 3. Update packages version
 
 Once the PR for bumping the code version is merged, the binary packages version
 needs to be updated for the Debian/Ubuntu packages. Brew metadata will be
@@ -173,7 +173,7 @@ build in the server. Now, the following needs to happen:
 
 The `release.py` script will perform all these actions.
 
-### Executing release.py
+### 4. Executing release.py
 
 Make sure you are in the source code repository before running `release.py`.
 You should be on the branch to be released, after the pull request bumping

--- a/release_instructions.md
+++ b/release_instructions.md
@@ -1,44 +1,5 @@
 # Gazebo Release Instructions
 
-The following picture shows the interactions triggered when using the release
-tool [`release.py`](https://github.com/gazebo-tooling/release-tools/blob/master/release.py) explained in this guide:
-
-![release.py interactions](releasing/images/releasepy_execution.png)
-
-Actions for releasing a new version of library (note that it can starts with
-ign or gz, ign/gz is used for this propose) `foo` with major version `X`:
-
- 1. [`release.py`](https://github.com/gazebo-tooling/release-tools/blob/master/release.py)
-    will generate a local tarball with the source code of the new version and
-    upload it to `osrf-distributions S3`.
- 1. `release.py` will start the following jobs in the build server
-    `build.osrfoundation.org`:
-      1. `ign/gz-fooX-debbuilder`: multiple calls for different Debian/Ubuntu releases
-      1. [`generic-release-homebrew_pull_request_updater`](https://build.osrfoundation.org/job/generic-release-homebrew_pull_request_updater/):
-      one call for Homebrew macOS release
- 1. `build.osrfoundation.org` jobs start the work of creating releases:
-      1. `ign/gz-fooX-debbuilder`: use tarball with release sources and metadata from `ign/gz-fooX-release`
-      1. `generic-release-homebrew_pull_request_updater`: use
-         [`homebrew-simulation`](https://github.com/osrf/homebrew-simulation/)
-         repository metadata together with the release sources
- 1. The output of the first round of initial jobs triggered by `release.py` is
-    different:
-      1. `ign/gz-fooX-debbuilder`: builds the Debian/Ubuntu .deb packages and
-         passes them to the `repository_uploader_packages` job
-      1. `generic-release-homebrew_pull_request_updater`: opens a
-         new PR to coordinate the release process in `homebrew-simulation`
- 1. [`repository_uploader_packages`](https://build.osrfoundation.org/job/repository_uploader_packages/)
-    imports the packages created by the `ign/gz-fooX-debbuilder` job (there will be
-    one build for each platform combination of Ubuntu/Debian release
-    and architecture) and uploads the .deb packages to
-    `packages.osrfoundation.org` and [`osrf-distributions S3`](http://gazebosim.org/distributions).
- 1. For macOS, the PR in `homebrew-simulation` waits for a comment from an
-    Gz developer with the order `build bottle` that will trigger the job
-    [`generic-release-homebrew_triggered_bottle_builder`](https://build.osrfoundation.org/job/generic-release-homebrew_bottle_builder/).
- 1. `generic-release-homebrew_triggered_bottle_builder`will use the tarball with
-    release sources from `osrf-distributions S3` to generate the binary bottles.
-    They will be uploaded to `osrf-distributions S3`.
-
 ## Initial setup
 
 A small number of configurations and credentials need to be made on the

--- a/release_instructions.md
+++ b/release_instructions.md
@@ -90,7 +90,7 @@ document.
 
    2. The current upstream version can be found in `CMakeLists.txt` file
    following the CMake `project declaration`:
- 
+
        ```cmake
        # Gz library named foo and version X.Y.Z
        project(gz-fooX VERSION X.Y.Z)
@@ -104,21 +104,19 @@ document.
       ```
 
   3. Together with bumping the version number, **updating the Changelog and Migration
-  documents** is required. The `Changelog.md` file and `Migration.md` files
-  are located at the top level of every Gz library. Modify them as needed.
+  documents** is required. For updating the `Changelog.md` file, the script
+  [source_changelog.bash](https://github.com/gazebo-tooling/release-tools/blob/master/source-repo-scripts/source_changelog.bash)
+  can be useful:
 
       ```bash
-      git commit CMakeList.xt
-      git commit Changelog.md
-      git commit Migration.md
-      git push origin ...
+      cd <path to source code>
+      bash <path to release-tools>/source-repo-scripts/source_changelog.bash <previous tag>
+      # e.g. bash ../release-tools/source-repo-scripts/source_changelog.bash 3.5.0
       ```
+  The `Migration.md` document needs to be updated if some breaking changes are in the Changelog.
 
-  4. Open a pull request for reviewing ([example PR](https://github.com/gazebosim/gz-physics/pull/132)).
-  Include a link comparing the current release branch to the
-  latest release ([example of a branch comparison](https://github.com/gazebosim/gz-sim/compare/ignition-gazebo3_3.5.0...ign-gazebo3)). Releases are tagged in GitHub repositories with the scheme
-  `ignition/gz-fooX_X.Y.Z` where foo is the name of the Gz library and X.Y.Z
-  the code version.
+  4. Open a pull request for reviewing ([example PR](https://github.com/gazebosim/gz-physics/pull/447)).
+  When opening a PR look for the "Release" section in the template and follow the instructions there.
 
 ### 3. Update packages version
 
@@ -152,7 +150,7 @@ information about how they are used).
     # Gz library named foo and major version X
     cd gz-fooX-release
     ~/release-tools/release-repo-scripts/changelog_spawn.sh X.Y.Z-R
-    
+
     # Example gz-cmake3 bumped from 3.0.0 to 3.0.1
     cd gz-cmake3-release
     ~/release-tools/release-repo-scripts/changelog_spawn.sh 3.0.1-1

--- a/release_instructions.md
+++ b/release_instructions.md
@@ -71,13 +71,13 @@ the process:
 ### 2. Update code version and changelogs
 
 The first step to get a new release ready is to update the current code (upstream)
-version (view the [versioning](#versioning) section for more information). This
+version (view the [versioning](release#versioning) section for more information). This
 bump could be in the major number (non-compatible changes), minor number (new
 features), patch number (patches and bugfixes).
 
 **Bumping major number** of the version implies some work to have the
 [metadata](#metadata-for-releasing) updated correctly. There is a [dedicated
-document](releasing/bump_major.md) that you should go through before continuing to work through the steps in this
+document](releasing/bump_major) that you should go through before continuing to work through the steps in this
 document.
 
    1. To update the upstream version a local checkout of the Gz library is
@@ -146,7 +146,7 @@ information about how they are used).
     git clone https://github.com/gazebo-release/gz-fooX-release
     ```
 
-2. To bump the package versions that will appear in Debian/Ubuntu binary packages there is a helper script in `release-tools` (see [prerequisites](#prerequisites)). The script is called `changelog_spawn.sh` and require to be executed while the active directory is a `release repository`:
+2. To bump the package versions that will appear in Debian/Ubuntu binary packages there is a helper script in `release-tools` (see [initial setup](#initial-setup)). The script is called `changelog_spawn.sh` and require to be executed while the active directory is a `release repository`:
 
     ```bash
     # Gz library named foo and major version X
@@ -171,7 +171,8 @@ build in the server. Now, the following needs to happen:
      1. Debian/Ubuntu: use `ign/gz-fooX-debbuilder` job names
      1. Brew: entry job is `generic-release-homebrew_pull_request_updater`
 
-The `release.py` script will perform all these actions.
+The `release.py` script will perform all these actions. For more information of all the processes
+triggered by the `release.py` script please check [the release process](release#using-the-gzdev-repository-command).
 
 ### 4. Executing release.py
 
@@ -183,7 +184,7 @@ Running `release.py` from the source code repository will generate and
 upload some Git tags ("release tags") to the source code repository.
 
 You will also need the token described in the [credentials
-section](#credentials).
+section](#access-and-credentials).
 
 **dry-run simulation mode**
 
@@ -251,7 +252,7 @@ ordering for package managers. [This information about versioning](https://class
 
 **release.py for revision bumps**
 
-Bumping the [revision number for binary packages](#versioning) is a special
+Bumping the [revision number for binary packages](release#versioning) is a special
 case of releasing since the original tarball with the source code will
 remain the same. Once the release repository is ready with the new release
 version, `release.py` needs the `--only-bump-revision-linux` flag:


### PR DESCRIPTION
The PR does an small number of fixes and improvements to the release instructions steps in order to simplify the document and leave it with a quick and compressive set of clear steps and don't host more information than the minimal needed. For doing this:

- Move the release.py diagram to release document 6e0441e76dd5afceeb6de0068f652eb3e1713929
- Add numbers to release steps 8c82dee5a0cbe76ec907b1fc9fbc6ec5506523f8
- Fix all broken links found c68b4ac6a2c776a68084eada5c196243c156f9df
- Add the source_changelog script and simplify the instructions c68b4ac6a2c776a68084eada5c196243c156f9df

Just related to organization in the releasing process description document:
- Move gzdev to its own section of other tools 6dd0d1b38b8f65b853224c458deba696f998b49f