### PR TITLE
Fix launch arg typo in macO installation instructions

### DIFF
--- a/garden/install_osx_src.md
+++ b/garden/install_osx_src.md
@@ -261,7 +261,7 @@ gz sim -v 4 shapes.sdf -s
 
 # launch gui in a seprate terminal
 # remember to source the workspace setup script
-gz sim -v 4 g
+gz sim -v 4 -g
 ```
 
 This is the end of the source install instructions; head back to the [Getting started](/docs/all/getstarted)

--- a/harmonic/install_osx_src.md
+++ b/harmonic/install_osx_src.md
@@ -259,7 +259,7 @@ gz sim -v 4 shapes.sdf -s
 
 # launch gui in a seprate terminal
 # remember to source the workspace setup script
-gz sim -v 4 g
+gz sim -v 4 -g
 ```
 
 This is the end of the source install instructions; head back to the [Getting started](/docs/all/getstarted)


### PR DESCRIPTION
Signed-off-by: Ian Chen <ichen@openrobotics.org>

# 🦟 Bug fix

## Summary

Fixes typo

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
