### PR TITLE
Change get_started to recommened Gz version per platform for installations

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -7,10 +7,28 @@ simulation using Gazebo.
 
 ## Step 1: Install
 
-Each release of Gazebo ships with a new installation tutorial. You can
-read [the latest installation tutorial here](/docs/latest/install). Please
-visit the [main documentation](/docs) pages for a list of all releases,
-along with links to their respective installation tutorials.
+The recommended installation for non expert users is the use of binary
+packages available for the platform to use when possible.
+
+|Platform|Gz Versions|
+|---|---|
+| Ubuntu 22.04 Jammy | [Gz Garden (recommended)](docs/garden/install_ubuntu), [Gz Fortress](docs/fortress/install_ubuntu)
+| Ubuntu 20.04 Focal | [Gz Garden (recommended)](docs/garden/install_buuntu), [Gz Fortress](docs/fortress/install_ubuntu), [Gz Citadel](docs/citadel/install_ubuntu)
+| Ubuntu 18.04 Bionic | [Gz Citadel](docs/citadel/install_ubuntu)
+| Mac Monterey | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Mac BigSur | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Mac Catalina | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+
+Windows support via conda-forge is not fully functional, there are known runtime problems
+[stoping Gz to work](https://github.com/gazebosim/gz-sim/issues/168).
+
+If the desired plaform is not listed above or if a particular feature in a
+given Gz release is needed, there is a installation package per release
+available with all the installation options:
+
+* [Gz Garden](docs/garden/install) installation options
+* [Gz Fortress](docs/fortress/install) installation options
+* [Gz Citadel](docs/citadel/install) installation options
 
 ## Step 2: Run
 

--- a/get_started.md
+++ b/get_started.md
@@ -23,12 +23,13 @@ Windows support via conda-forge is not fully functional, there are known runtime
 [Gazebo for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
 
 If the desired platform is not listed above or if a particular feature in a
-given Gazebo release is needed, there is an installation package per release
-available with all the installation options:
+given [Gazebo release](https://gazebosim.org/docs/latest/releases) is needed,
+there is an installation package per release available with all the
+installation options:
 
-* [Gazebo Garden](docs/garden/install) installation options
-* [Gazebo Fortress](docs/fortress/install) installation options
-* [Gazebo Citadel](docs/citadel/install) installation options
+* [Gazebo Garden installation](docs/garden/install) options (EOL 2024 Sep)
+* [Gazebo Fortress (LTS) installation](docs/fortress/install) options (EOL 2026 Sep)
+* [Gazebo Citadel (LTS) installation](docs/citadel/install) options (EOL 2024 Dec)
 
 ## Step 2: Run
 

--- a/get_started.md
+++ b/get_started.md
@@ -13,17 +13,17 @@ packages available for the platform to use:
 |Platform|Gz Versions|
 |---|---|
 | Ubuntu 22.04 Jammy | [Gz Garden](docs/garden/install_ubuntu) (recommended) and [Gz Fortress](docs/fortress/install_ubuntu)
-| Ubuntu 20.04 Focal | [Gz Garden](docs/garden/install_buuntu) (recommended), [Gz Fortress](docs/fortress/install_ubuntu) and [Gz Citadel](docs/citadel/install_ubuntu)
+| Ubuntu 20.04 Focal | [Gz Garden](docs/garden/install_ubuntu) (recommended), [Gz Fortress](docs/fortress/install_ubuntu) and [Gz Citadel](docs/citadel/install_ubuntu)
 | Ubuntu 18.04 Bionic | [Gz Citadel](docs/citadel/install_ubuntu)
 | Mac Monterey | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
 | Mac BigSur | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
 | Mac Catalina | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
 
 Windows support via conda-forge is not fully functional, there are known runtime problems
-[stoping Gz to work](https://github.com/gazebosim/gz-sim/issues/168).
+[stopping Gz to work](https://github.com/gazebosim/gz-sim/issues/168).
 
-If the desired plaform is not listed above or if a particular feature in a
-given Gz release is needed, there is a installation package per release
+If the desired platform is not listed above or if a particular feature in a
+given Gz release is needed, there is an installation package per release
 available with all the installation options:
 
 * [Gz Garden](docs/garden/install) installation options

--- a/get_started.md
+++ b/get_started.md
@@ -7,7 +7,7 @@ simulation using Gazebo.
 
 ## Step 1: Install
 
-The recommended installation for non expert users is the use of binary
+The recommended installation for new users is the use of binary
 packages available for the platform to use:
 
 |Platform|Gz Versions|
@@ -20,7 +20,7 @@ packages available for the platform to use:
 | Mac Catalina | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
 
 Windows support via conda-forge is not fully functional, there are known runtime problems
-[stopping Gz to work](https://github.com/gazebosim/gz-sim/issues/168).
+[Gz for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
 
 If the desired platform is not listed above or if a particular feature in a
 given Gz release is needed, there is an installation package per release

--- a/get_started.md
+++ b/get_started.md
@@ -10,25 +10,25 @@ simulation using Gazebo.
 The recommended installation for new users is the use of binary
 packages available for the platform to use:
 
-|Platform|Gz Versions|
+|Platform|Gazebo Versions|
 |---|---|
-| Ubuntu 22.04 Jammy | [Gz Garden](docs/garden/install_ubuntu) (recommended) and [Gz Fortress](docs/fortress/install_ubuntu)
-| Ubuntu 20.04 Focal | [Gz Garden](docs/garden/install_ubuntu) (recommended), [Gz Fortress](docs/fortress/install_ubuntu) and [Gz Citadel](docs/citadel/install_ubuntu)
-| Ubuntu 18.04 Bionic | [Gz Citadel](docs/citadel/install_ubuntu)
-| Mac Monterey | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
-| Mac BigSur | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
-| Mac Catalina | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Ubuntu 22.04 Jammy | [Gazebo Garden](docs/garden/install_ubuntu) (recommended) and [Gazebo Fortress](docs/fortress/install_ubuntu)
+| Ubuntu 20.04 Focal | [Gazebo Garden](docs/garden/install_ubuntu) (recommended), [Gazebo Fortress](docs/fortress/install_ubuntu) and [Gazebo Citadel](docs/citadel/install_ubuntu)
+| Ubuntu 18.04 Bionic | [Gazebo Citadel](docs/citadel/install_ubuntu)
+| Mac Monterey | [Gazebo Garden](docs/garden/install_osx) (recommended), [Gazebo Fortress](docs/fortress/install_osx) and [Gazebo Citadel](docs/citadel/install_osx)
+| Mac BigSur | [Gazebo Garden](docs/garden/install_osx) (recommended), [Gazebo Fortress](docs/fortress/install_osx) and [Gazebo Citadel](docs/citadel/install_osx)
+| Mac Catalina | [Gazebo Garden](docs/garden/install_osx) (recommended), [Gazebo Fortress](docs/fortress/install_osx) and [Gazebo Citadel](docs/citadel/install_osx)
 
 Windows support via conda-forge is not fully functional, there are known runtime problems
-[Gz for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
+[Gazebo for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
 
 If the desired platform is not listed above or if a particular feature in a
-given Gz release is needed, there is an installation package per release
+given Gazebo release is needed, there is an installation package per release
 available with all the installation options:
 
-* [Gz Garden](docs/garden/install) installation options
-* [Gz Fortress](docs/fortress/install) installation options
-* [Gz Citadel](docs/citadel/install) installation options
+* [Gazebo Garden](docs/garden/install) installation options
+* [Gazebo Fortress](docs/fortress/install) installation options
+* [Gazebo Citadel](docs/citadel/install) installation options
 
 ## Step 2: Run
 

--- a/get_started.md
+++ b/get_started.md
@@ -8,7 +8,7 @@ simulation using Gazebo.
 ## Step 1: Install
 
 The recommended installation for non expert users is the use of binary
-packages available for the platform to use when possible.
+packages available for the platform to use:
 
 |Platform|Gz Versions|
 |---|---|

--- a/get_started.md
+++ b/get_started.md
@@ -12,12 +12,12 @@ packages available for the platform to use when possible.
 
 |Platform|Gz Versions|
 |---|---|
-| Ubuntu 22.04 Jammy | [Gz Garden (recommended)](docs/garden/install_ubuntu), [Gz Fortress](docs/fortress/install_ubuntu)
-| Ubuntu 20.04 Focal | [Gz Garden (recommended)](docs/garden/install_buuntu), [Gz Fortress](docs/fortress/install_ubuntu), [Gz Citadel](docs/citadel/install_ubuntu)
+| Ubuntu 22.04 Jammy | [Gz Garden](docs/garden/install_ubuntu) (recommended) and [Gz Fortress](docs/fortress/install_ubuntu)
+| Ubuntu 20.04 Focal | [Gz Garden](docs/garden/install_buuntu) (recommended), [Gz Fortress](docs/fortress/install_ubuntu) and [Gz Citadel](docs/citadel/install_ubuntu)
 | Ubuntu 18.04 Bionic | [Gz Citadel](docs/citadel/install_ubuntu)
-| Mac Monterey | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
-| Mac BigSur | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
-| Mac Catalina | [Gz Garden (recommended)](docs/garden/install_osx), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Mac Monterey | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Mac BigSur | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
+| Mac Catalina | [Gz Garden](docs/garden/install_osx) (recommended), [Gz Fortress](docs/fortress/install_osx) and [Gz Citadel](docs/citadel/install_osx)
 
 Windows support via conda-forge is not fully functional, there are known runtime problems
 [stoping Gz to work](https://github.com/gazebosim/gz-sim/issues/168).


### PR DESCRIPTION
# 🎉 New feature

## Summary

The PR tries to simplify the election of the Gz version for the users. Basically it provides a recommendation in the landing page of main docs page https://gazebosim.org/docs and the landing page of releases (i.e https://gazebosim.org/docs/garden). It also includes a clear warning about Windows and leave it out of the table.

The PR will require some effort when we release a new version or when a version is EOL but I think that could worth it.

### Current situation problems

I think that there is a number of issues currently that are a source of confusion:

 * The Gz version selected in the top left corner named "Release" is not preserved when clicking links. 
 * The Gz version selected by default in the top left corner named "Release" is the one in development which leaves the user without binary install methods.

Both points in combination cause the effect of:
When being in a landing page of a given distribution (i.e Garden https://gazebosim.org/docs/garden), there are two links in the first step 1 install point named `latest installation tutorial here` and `Please visit the main documentation pages for a list of all releases` both are redirecting to Harmonic (development version).

### Follow up work

A new PR to be sent to clarify the options for the ROS users in the same way that [we have for gazebo-classic](https://classic.gazebosim.org/tutorials?tut=ros_wrapper_versions&cat=connect_ros).

## Checklist
- [x] Signed all commits for DCO