### PR TITLE
Harmonic: bump msgs, transport, and fuel tools

### DIFF
--- a/harmonic/install.md
+++ b/harmonic/install.md
@@ -28,18 +28,18 @@ This list of library versions may change up to the release date.
 | ------------------ |:-------------:|
 |   gz-cmake         |       3.x     |
 |   gz-common        |       5.x     |
-|   gz-fuel-tools    |       8.x     |
+|   gz-fuel-tools    |       9.x     |
 |   gz-sim           |       8.x     |
 |   gz-gui           |       8.x     |
 |   gz-launch        |       7.x     |
 |   gz-math          |       7.x     |
-|   gz-msgs          |       9.x     |
+|   gz-msgs          |      10.x     |
 |   gz-physics       |       6.x     |
 |   gz-plugin        |       2.x     |
 |   gz-rendering     |       8.x     |
 |   gz-sensors       |       8.x     |
 |   gz-tools         |       2.x     |
-|   gz-transport     |      12.x     |
+|   gz-transport     |      13.x     |
 |   gz-utils         |       2.x     |
 |   sdformat         |      13.x     |
 


### PR DESCRIPTION
# 🎉 New feature

## Summary

Bump msgs to 10, transport to 13, and fuel-tools to 9

Part of https://github.com/gazebo-tooling/release-tools/issues/878


## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

