### PR TITLE
Style and other improvements for get_started and ros_installation

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -7,8 +7,10 @@ simulation using Gazebo.
 
 ## Step 1: Install
 
-***Note:*** If you are a [ROS](https://ros.org) user, please first read our tutorial about
+<div class="warning">
+<strong>Note:</strong> If you are a [ROS](https://ros.org) user, please first read our tutorial about
 the [ROS/Gazebo installation](ros_installation).
+</div>
 
 The recommended installation for new users is the use of binary
 packages available for the platform to use:

--- a/get_started.md
+++ b/get_started.md
@@ -23,9 +23,7 @@ packages available for the platform to use:
 | Mac Monterey | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
 | Mac BigSur | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
 | Mac Catalina | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
-
-Windows support via conda-forge is not fully functional, there are known runtime problems
-[Gazebo for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
+| Windows | Support via conda-forge is not fully functional, there are known runtime problems [Gazebo for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
 
 If the desired platform is not listed above or if a particular feature in a
 given [Gazebo release](/docs/latest/releases) is needed,

--- a/get_started.md
+++ b/get_started.md
@@ -23,7 +23,7 @@ packages available for the platform to use:
 | Mac Monterey | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
 | Mac BigSur | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
 | Mac Catalina | [Gazebo Garden](/docs/garden/install_osx) (recommended), [Gazebo Fortress](/docs/fortress/install_osx) and [Gazebo Citadel](/docs/citadel/install_osx)
-| Windows | Support via conda-forge is not fully functional, there are known runtime problems [Gazebo for Windows Issue](https://github.com/gazebosim/gz-sim/issues/168).
+| Windows | Support via Conda-Forge is not fully functional, as there are known runtime issues [see this issue for details](https://github.com/gazebosim/gz-sim/issues/168).
 
 If the desired platform is not listed above or if a particular feature in a
 given [Gazebo release](/docs/latest/releases) is needed,

--- a/ros_installation.md
+++ b/ros_installation.md
@@ -157,7 +157,7 @@ source.
    * [ROS1 Noetic](https://github.com/gazebosim/ros_gz/tree/noetic#from-source)
      * Be sure of using `export GZ_VERSION=edifice`
 
-## Using the latest Gazebo binary versions
+## Using the latest Gazebo versions from each Gazebo distribution
 
 The Gazebo team usually backport and release new versions of each of the supported
 Gazebo releases and libraries (i.e: bumping `gz-sim 7.0.0` to gz-sim `7.1.0`). These

--- a/ros_installation.md
+++ b/ros_installation.md
@@ -42,14 +42,14 @@ The easiest way of installing Gazebo is to use binary packages. There are two ma
 repositories which host Gazebo simulator and Gazebo libraries: one is `packages.ros.org` and the
 other is `packages.osrfoundation.org`. At the time of writing:
 
- * ***packages.ros.org***
+ * **packages.ros.org**
    * ROS1 Noetic: Gazebo Citadel
    * ROS2 Foxy: Gazebo Citadel
    * ROS2 Galactic: Gazebo Edifice
    * ROS2 Humble: Gazebo Fortress
    * ROS2 Rolling: Gazebo Fortress (changing frequently)
 
- * ***packages.osrfoundation.org***
+ * **packages.osrfoundation.org**
    * Gazebo Citadel
    * Gazebo Edifice
    * Gazebo Fortress

--- a/ros_installation.md
+++ b/ros_installation.md
@@ -56,7 +56,7 @@ other is `packages.osrfoundation.org`. At the time of writing:
    * Gazebo Garden
 
 This means that including the osrfoundation repository is not strictly needed
-to get the Gazebo binary packages it can be installed from the ROS
+to get the Gazebo binary packages, it can be installed from the ROS
 repository.
 
 ## Installing the default Gazebo version for a ROS distribution using binary installations

--- a/ros_installation.md
+++ b/ros_installation.md
@@ -161,7 +161,7 @@ source.
 
 The Gazebo team usually backport and release new versions of each of the supported
 Gazebo releases and libraries (i.e: bumping `gz-sim 7.0.0` to gz-sim `7.1.0`). These
-updates are hosted first in the osrfoundation repository. The ROS repository
+updates are hosted first in the packages.osrfoundation.org repository. The ROS repository
 syncs from the osrfoundation repository frequently but versions can be
 different.
 

--- a/ros_installation.md
+++ b/ros_installation.md
@@ -56,7 +56,7 @@ other is `packages.osrfoundation.org`. At the time of writing:
    * Gazebo Garden
 
 This means that including the osrfoundation repository is not strictly needed
-to get the Gazebo binary package in Ubuntu. It can be installed from the ROS
+to get the Gazebo binary packages it can be installed from the ROS
 repository.
 
 ## Installing the default Gazebo version for a ROS distribution using binary installations


### PR DESCRIPTION
One fix or improvement per commit:

- Use warning div for ROS note
- Add Windows to the table of distros
- Fix old gazebo classic reference
- Use plain bold style
- Improve header description
- Clarify URL for osrfoundation repo
