### PR TITLE
Use html links in warning block

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -8,8 +8,8 @@ simulation using Gazebo.
 ## Step 1: Install
 
 <div class="warning">
-<strong>Note:</strong> If you are a [ROS](https://ros.org) user, please first read our tutorial about
-the [ROS/Gazebo installation](ros_installation).
+  <strong>Note:</strong> If you are a <a href="https://ros.org">ROS</a> user, please first read our tutorial about
+  the <a href="ros_installation">ROS/Gazebo installation</a>.
 </div>
 
 The recommended installation for new users is the use of binary


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Uses `<a>` tags since Markdown links don't work inside html blocks

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
