### PR TITLE
Add note about MESA_GL_VERSION_OVERRIDE variable in troubleshooting guide

### DIFF
--- a/fortress/troubleshooting.md
+++ b/fortress/troubleshooting.md
@@ -147,6 +147,10 @@ or force software rendering
 
     export LIBGL_ALWAYS_SOFTWARE=1
 
+If you are using MESA drivers, you can also try overriding the OpenGL version
+
+    export MESA_GL_VERSION_OVERRIDE=3.3
+
 The Ogre 2 debs from the osrfoundation repository are built from a fork of
 Ogre's `v2-2` branch with changes needed for deb packaging and allowing it to
 be co-installable with Ogre 1.x. The code can be found here:

--- a/garden/troubleshooting.md
+++ b/garden/troubleshooting.md
@@ -150,6 +150,10 @@ or force software rendering
 
     export LIBGL_ALWAYS_SOFTWARE=1
 
+If you are using MESA drivers, you can also try overriding the OpenGL version
+
+    export MESA_GL_VERSION_OVERRIDE=3.3
+
 The Ogre 2 debs from the osrfoundation repository are built from a fork of
 Ogre's `v2-3` branch with changes needed for deb packaging and allowing it to
 be co-installable with Ogre 1.x. The code can be found here:


### PR DESCRIPTION
Users doing software rendering with mesa drivers could still run into crashes. 

The troubleshooting guide already mentions the relevant error message: 

`"OGRE EXCEPTION(3:RenderingAPIException): OpenGL 3.3 is not supported. Please update your graphics card drivers."`, 

and provided some instructions on things to try. Here we add another env var that can be set for users who are using mesa drivers.

Related PR: https://github.com/gazebosim/gz-rendering/pull/829
