### PR TITLE
Add per-library tutorial links to tutorial page

### DIFF
--- a/citadel/tutorials.md
+++ b/citadel/tutorials.md
@@ -22,5 +22,25 @@ These tutorials cover general concepts to help get you started with Ignition.
 * [ROS Integration](ros_integration)
 * [ROS 2 Integration](ros2_integration)
 
+## Per-library tutorials
 
-More specific content correlating to each Ignition library can be found under the *API & Tutorials* sections on the [Libraries page](/libs).
+See the *API & Tutorials* sections on the [Libraries page](/libs) page for more specific content correlating to each Gazebo library.
+
+The entrypoint library is Sim.
+- [Sim](/api/sim/3/tutorials.html)
+
+Other libraries:
+- [Cmake](/api/cmake/2/tutorials.html)
+- [Common](/api/common/3/tutorials.html)
+- [Fuel_tools](/api/fuel_tools/4/tutorials.html)
+- [Gui](/api/gui/3/tutorials.html)
+- [Launch](/api/launch/2/tutorials.html)
+- [Math](/api/math/6/tutorials.html)
+- [Msgs](/api/msgs/5/tutorials.html)
+- [Physics](/api/physics/2/tutorials.html)
+- [Plugin](/api/plugin/1/tutorials.html)
+- [Rendering](/api/rendering/3/tutorials.html)
+- [Sdformat](/api/sdformat/9/tutorials.html)
+- [Sensors](/api/sensors/3/tutorials.html)
+- [Tools](/api/tools/1/tutorials.html)
+- [Transport](/api/transport/8/tutorials.html)

--- a/fortress/tutorials.md
+++ b/fortress/tutorials.md
@@ -22,5 +22,26 @@ These tutorials cover general concepts to help get you started with Ignition.
 * [ROS Integration](ros_integration)
 * [ROS 2 Integration](ros2_integration)
 
+## Per-library tutorials
 
-More specific content correlating to each Ignition library can be found under the *API & Tutorials* sections on the [Libraries page](/libs).
+See the *API & Tutorials* sections on the [Libraries page](/libs) page for more specific content correlating to each Gazebo library.
+
+The entrypoint library is Sim.
+- [Sim](/api/sim/6/tutorials.html)
+
+Other libraries:
+- [Cmake](/api/cmake/2/tutorials.html)
+- [Common](/api/common/4/tutorials.html)
+- [Fuel_tools](/api/fuel_tools/7/tutorials.html)
+- [Gui](/api/gui/6/tutorials.html)
+- [Launch](/api/launch/5/tutorials.html)
+- [Math](/api/math/6/tutorials.html)
+- [Msgs](/api/msgs/8/tutorials.html)
+- [Physics](/api/physics/5/tutorials.html)
+- [Plugin](/api/plugin/1/tutorials.html)
+- [Rendering](/api/rendering/6/tutorials.html)
+- [Sdformat](/api/sdformat/12/tutorials.html)
+- [Sensors](/api/sensors/6/tutorials.html)
+- [Tools](/api/tools/1/tutorials.html)
+- [Transport](/api/transport/11/tutorials.html)
+- [Utils](/api/utils/1/tutorials.html)

--- a/garden/tutorials.md
+++ b/garden/tutorials.md
@@ -21,5 +21,26 @@ These tutorials cover general concepts to help get you started with Gazebo.
 
 * [ROS 2 Integration](ros2_integration)
 
+## Per-library tutorials
 
-More specific content correlating to each Gazebo library can be found under the *API & Tutorials* sections on the [Libraries page](/libs).
+See the *API & Tutorials* sections on the [Libraries page](/libs) page for more specific content correlating to each Gazebo library.
+
+The entrypoint library is Sim.
+- [Sim](/api/sim/7/tutorials.html)
+
+Other libraries:
+- [Cmake](/api/cmake/3/tutorials.html)
+- [Common](/api/common/5/tutorials.html)
+- [Fuel_tools](/api/fuel_tools/8/tutorials.html)
+- [Gui](/api/gui/7/tutorials.html)
+- [Launch](/api/launch/6/tutorials.html)
+- [Math](/api/math/7/tutorials.html)
+- [Msgs](/api/msgs/9/tutorials.html)
+- [Physics](/api/physics/6/tutorials.html)
+- [Plugin](/api/plugin/2/tutorials.html)
+- [Rendering](/api/rendering/7/tutorials.html)
+- [Sdformat](/api/sdformat/13/tutorials.html)
+- [Sensors](/api/sensors/7/tutorials.html)
+- [Tools](/api/tools/2/tutorials.html)
+- [Transport](/api/transport/12/tutorials.html)
+- [Utils](/api/utils/2/tutorials.html)


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-web/gazebosim-web-frontend/issues/19

## Summary

Add per-library tutorials directly to tutorial page.

The links are quite manual. The numbers would have to be changed each time we do version bumps. I don't know if it can be automated. We manually change numbers in other Markdown files, so maybe this is the way to go?

## Test it

Use `docker_dev` branch in gazebosim-web-frontend repo and follow steps here https://github.com/gazebo-web/gazebosim-web-frontend/tree/docker_dev#docker-development

(Of course, I say that, but I'm not able to get the `docker-compose` to work. Maybe someone who has it working @azeey can preview it.)

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.