### PR TITLE
Add section on troubleshooting Gazebo on Wayland

### DIFF
--- a/fortress/troubleshooting.md
+++ b/fortress/troubleshooting.md
@@ -165,6 +165,23 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 If that loads, you can continue to use Ignition with Ogre 1, just use the
 `--render-engine ogre` option.
 
+### Wayland issues
+
+For users on Wayland, you will need to make sure Gazebo is launched with
+XWayland.
+
+If you see an error message like the one below:
+
+```
+Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in GLXWindow::create at ./RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp (line 165)
+```
+
+try unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
+
+```sh
+env -u WAYLAND_DISPLAY ign gazebo -v 4 shapes.sdf
+```
+
 ## Windows
 
 ### VisualStudioVersion is not set, please run within a Visual Studio Command Prompt.

--- a/garden/troubleshooting.md
+++ b/garden/troubleshooting.md
@@ -168,6 +168,23 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 If that loads, you can continue to use Gazebo with Ogre 1, just use the
 `--render-engine ogre` option.
 
+### Wayland issues
+
+For users on Wayland, you will need to make sure Gazebo is launched with
+XWayland.
+
+If you see an error message like the one below:
+
+```
+Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in GLXWindow::create at ./RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp (line 165)
+```
+
+try unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
+
+```sh
+env -u WAYLAND_DISPLAY gz sim -v 4 shapes.sdf
+```
+
 ## Windows
 
 ### VisualStudioVersion is not set, please run within a Visual Studio Command Prompt.

--- a/harmonic/troubleshooting.md
+++ b/harmonic/troubleshooting.md
@@ -163,6 +163,23 @@ that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
 If that loads, you can continue to use Ignition with Ogre 1, just use the
 `--render-engine ogre` option.
 
+### Wayland issues
+
+For users on Wayland, you will need to make sure Gazebo is launched with
+XWayland.
+
+If you see an error message like the one below:
+
+```
+Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in GLXWindow::create at ./RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp (line 165)
+```
+
+try unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
+
+```sh
+env -u WAYLAND_DISPLAY gz sim -v 4 shapes.sdf
+```
+
 ## Windows
 
 ### VisualStudioVersion is not set, please run within a Visual Studio Command Prompt.


### PR DESCRIPTION
Related issue: https://github.com/gazebosim/gz-sim/issues/1934

Running Gazebo on Wayland may result in a crash with an error msg about missing current gl context. Updated the troubleshooting guide with a section on Wayland with the solution mentioned in https://github.com/gazebosim/gz-sim/issues/1934#issuecomment-1487694481 about unsetting the `WAYLAND_DISPLAY` env var and making gz use XWayland