### PR TITLE
troubleshooting.md: update brew ruby PATH

### DIFF
--- a/garden/troubleshooting.md
+++ b/garden/troubleshooting.md
@@ -64,7 +64,7 @@ The issue is related to OSX System Integrity Protection (SIP). The workaround is
 brew install ruby
 
 # Add the following to ~/.bashrc
-export PATH=/usr/local/Cellar/ruby/2.6.5/bin:$PATH
+export PATH=$(brew --prefix)/opt/ruby/bin:$PATH
 
 # Source ~/.bashrc in terminal
 . ~/.bashrc


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/gz-sim/issues/1990

## Summary

The recommended `PATH` change to support `ruby` from `homebrew-core` is not generic enough since it presumes brew is in `/usr/local` when it could be in `/opt/homebrew` and also using a versioned Cellar path, when an `opt` path is better.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
