### PR TITLE
Update wording about commit signoffs

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -193,7 +193,7 @@ get acquainted with this development process.
    your life easier.
 
 1. **Write your code.** This is the fun part, but is good to remember:
-   - Always [sign your commits](https://docs.github.com/en/github/authenticating-to-github/signing-commits) (See the bullet about Developer Certificate of Origin in the [Process](https://gazebosim.org/docs/all/contributing#process) section below)
+   - Always [signoff on your commits](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository#about-commit-signoffs) (See the bullet about Developer Certificate of Origin in the [Process](https://gazebosim.org/docs/all/contributing#process) section below)
    - Look at the existing code and try to maintain the existing style and pattern as much as possible
    - **Always** keep your branch updated with the original repository
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Signing off on a commit is [different](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository#about-commit-signoffs) from signing a commit. I believe we only require signing off.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.