### PR TITLE
Update install_windows_src tutorial for Harmonic

### DIFF
--- a/harmonic/install_windows_src.md
+++ b/harmonic/install_windows_src.md
@@ -1,4 +1,4 @@
-# Source Installation on Windows 10
+# Source Installation on Windows 10 or 11
 
 Command line tools, DART physics engine, and GUI capabilities are
 not currently supported in Windows. These functionalities correspond to the currently
@@ -11,8 +11,9 @@ You will still be able to use `TPE` as a physics engine
 
 ## Install dependencies
 
-1. Install a [Conda package management system](https://docs.conda.io/projects/conda/en/latest/user-guide/install/download.html).
-   Miniconda suffices. You will likely want to check the box to add `conda` to your `PATH`
+1. Install a conda distribution. As Gazebo uses all dependencies from the conda-forge channel,
+   we sugged to install miniforge following [the official miniforge installation docs](https://github.com/conda-forge/miniforge#windows)
+   You will likely want to check the box to add `conda` to your `PATH`
    during the installation process so that you won't have to do this step manually.
 
 2. Install [Visual Studio 2019](https://visualstudio.microsoft.com/downloads/).
@@ -47,9 +48,9 @@ You will still be able to use `TPE` as a physics engine
 
   ```bash
   conda install cmake git vcstool curl pkg-config ^
-  colcon-common-extensions eigen freeimage gdal gts ^
+  colcon-common-extensions dartsim eigen freeimage gdal gts ^
   glib dlfcn-win32 ffmpeg ruby tinyxml2 tinyxml ^
-  protobuf urdfdom zeromq cppzmq ogre jsoncpp ^
+  libprotobuf urdfdom zeromq cppzmq ogre ogre-next jsoncpp ^
   libzip qt pybind11 --channel conda-forge
   ```
 

--- a/harmonic/install_windows_src.md
+++ b/harmonic/install_windows_src.md
@@ -12,7 +12,7 @@ You will still be able to use `TPE` as a physics engine
 ## Install dependencies
 
 1. Install a conda distribution. As Gazebo uses all dependencies from the conda-forge channel,
-   we sugged to install miniforge following [the official miniforge installation docs](https://github.com/conda-forge/miniforge#windows)
+   we suggest to install miniforge following [the official miniforge installation docs](https://github.com/conda-forge/miniforge#windows)
    You will likely want to check the box to add `conda` to your `PATH`
    during the installation process so that you won't have to do this step manually.
 


### PR DESCRIPTION
# 🎉 New feature


## Summary

I update the instruction for installation from source on Windows.

Improvements include:
* Suggest to use miniforge to install conda instead of miniconda, as we always use conda-forge dependencies, this should reduce the possibility of people installing a bit of packages from conda-forge and a bit from defaults/anaconda, that is not supported (see https://github.com/gazebosim/gz-sim/issues/2082)
* Suggest to also install dartsim and ogre-next as dependencies, that now are available in conda-forge
* Suggest to install libprotobuf (the C++ libraries) instead of protobuf (the Python library)
* Mention in the documentation that install instructions are valid also for Windows 11

I do not know what to do for citadel, fortress and garden documentation, I can do similar changes there (perhaps excluding adding ogre-next and dartsim that I did not tested with older distributions)

## Test it

Follow the documentation on Windows.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

