### PR TITLE
Fix path to release.py in release instructions page

### DIFF
--- a/release_instructions.md
+++ b/release_instructions.md
@@ -212,7 +212,7 @@ git checkout ign/gz-fooX
 cd gz-cmake3
 git checkout gz-cmake3
 # please replace <jenkins_token> with real release token (check crendentials section)
-~/release-tools/release-repo-scripts/release.py gz-cmake3 3.0.1 <jenkins_token>
+~/release-tools/release.py gz-cmake3 3.0.1 <jenkins_token>
 ```
 
 **release.py for prereleases or nightlies**
@@ -226,7 +226,7 @@ to be set. The `--upload-to-repo` argument is mandatory when running
 cd gz-cmake3
 git checkout gz-cmake3
 # please replace <jenkins_token> with real release token (check crendentials section)
-~/release-tools/release-repo-scripts/release.py gz-cmake3 3.0.0~pre1 <jenkins_token> --upload-to-repo prerelease
+~/release-tools/release.py gz-cmake3 3.0.0~pre1 <jenkins_token> --upload-to-repo prerelease
 ```
 
 Nightly invocation is generally coded in the server. The version will be
@@ -239,7 +239,7 @@ branch pointed by `--nightly-src-branch`.
 cd gz-cmake3
 git checkout gz-cmake3
 # please replace <jenkins_token> with real release token (check crendentials section)
-~/release-tools/release-repo-scripts/release.py gz-cmake3 3.0.0~pre1 <jenkins_token> --upload-to-repo nightly --nightly-src-branch main
+~/release-tools/release.py gz-cmake3 3.0.0~pre1 <jenkins_token> --upload-to-repo nightly --nightly-src-branch main
 
 ```
 
@@ -260,7 +260,7 @@ version, `release.py` needs the `--only-bump-revision-linux` flag:
 cd gz-cmake3
 git checkout gz-cmake3
 # please replace <jenkins_token> with real release token (check crendentials section)
-~/release-tools/release-repo-scripts/release.py gz-cmake3 3.0.1 <jenkins_token> --only-bump-revision-linux -release-version 2
+~/release-tools/release.py gz-cmake3 3.0.1 <jenkins_token> --only-bump-revision-linux -release-version 2
 ```
 
 ## Checking the Building Process


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
Fix [release.py](https://github.com/gazebo-tooling/release-tools/blob/master/release.py) path

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

