### PR TITLE
Fix `RUN` statement in Harmonic docker file

### DIFF
--- a/tools/Dockerfile.harmonic
+++ b/tools/Dockerfile.harmonic
@@ -17,7 +17,7 @@ ARG AWS_SECRET_ACCESS_KEY
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
 RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-prerelease $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-prerelease.list > /dev/null \
-  apt-get update
+  && apt-get update
 
 COPY scripts/build_gz.sh scripts/build_gz.sh
 


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Without this fix, the `apt update` is simply ignored and the doc builds fail because they won't find prerelease packages.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
