### PR TITLE
Fix harmonic per-library tutorial links

### DIFF
--- a/harmonic/tutorials.md
+++ b/harmonic/tutorials.md
@@ -26,21 +26,21 @@ These tutorials cover general concepts to help get you started with Gazebo.
 See the *API & Tutorials* sections on the [Libraries page](/libs) page for more specific content correlating to each Gazebo library.
 
 The entrypoint library is Sim.
-- [Sim](/api/sim/7/tutorials.html)
+- [Sim](/api/sim/8/tutorials.html)
 
 Other libraries:
 - [Cmake](/api/cmake/3/tutorials.html)
 - [Common](/api/common/5/tutorials.html)
-- [Fuel_tools](/api/fuel_tools/8/tutorials.html)
-- [Gui](/api/gui/7/tutorials.html)
-- [Launch](/api/launch/6/tutorials.html)
+- [Fuel_tools](/api/fuel_tools/9/tutorials.html)
+- [Gui](/api/gui/8/tutorials.html)
+- [Launch](/api/launch/7/tutorials.html)
 - [Math](/api/math/7/tutorials.html)
-- [Msgs](/api/msgs/9/tutorials.html)
-- [Physics](/api/physics/6/tutorials.html)
+- [Msgs](/api/msgs/10/tutorials.html)
+- [Physics](/api/physics/7/tutorials.html)
 - [Plugin](/api/plugin/2/tutorials.html)
-- [Rendering](/api/rendering/7/tutorials.html)
-- [Sensors](/api/sensors/7/tutorials.html)
+- [Rendering](/api/rendering/8/tutorials.html)
+- [Sensors](/api/sensors/8/tutorials.html)
 - [Tools](/api/tools/2/tutorials.html)
-- [Transport](/api/transport/12/tutorials.html)
+- [Transport](/api/transport/13/tutorials.html)
 - [Utils](/api/utils/2/tutorials.html)
 - [Sdformat](/api/sdformat/13/)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

Fix all the per-library tutorial links, except for sdf14, which doesn't exist yet and would be https://gazebosim.org/api/sdformat/14

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.