### PR TITLE
Remove use of enable_gcc8 script to fix focal builds

### DIFF
--- a/tools/Dockerfile.citadel
+++ b/tools/Dockerfile.citadel
@@ -17,9 +17,6 @@ ARG AWS_SECRET_ACCESS_KEY
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
 RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
-COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
-RUN scripts/enable_gcc8.sh
-
 COPY scripts/build_gz.sh scripts/build_gz.sh
 
 RUN echo ::endgroup::

--- a/tools/Dockerfile.fortress
+++ b/tools/Dockerfile.fortress
@@ -17,9 +17,6 @@ ARG AWS_SECRET_ACCESS_KEY
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
 RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
-COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
-RUN scripts/enable_gcc8.sh
-
 COPY scripts/build_gz.sh scripts/build_gz.sh
 
 RUN echo ::endgroup::

--- a/tools/Dockerfile.garden
+++ b/tools/Dockerfile.garden
@@ -17,9 +17,6 @@ ARG AWS_SECRET_ACCESS_KEY
 COPY scripts/install_common_deps.sh scripts/install_common_deps.sh
 RUN scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
 
-COPY scripts/enable_gcc8.sh scripts/enable_gcc8.sh
-RUN scripts/enable_gcc8.sh
-
 COPY scripts/build_gz.sh scripts/build_gz.sh
 
 RUN echo ::endgroup::


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Focal based docker containers were failing to build documentation because running `enable_gcc8.sh` script fails. 

Try using:
```
docker build -t gz-fortress-docs -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD=foo --build-arg GZ_VERSION_DATE=5 --build-arg AWS_ACCESS_KEY_ID=foo --build-arg AWS_SECRET_ACCESS_KEY=foo .
```

and you'd get
```
STEP 12/28: RUN scripts/enable_gcc8.sh

sudo apt-get install g++-8
Reading package lists...
Building dependency tree...
Reading state information...
The following additional packages will be installed:
  cpp-8 gcc-8 gcc-8-base libgcc-8-dev libmpx2 libstdc++-8-dev
Suggested packages:
  gcc-8-locales g++-8-multilib gcc-8-doc gcc-8-multilib libstdc++-8-doc
The following NEW packages will be installed:
  cpp-8 g++-8 gcc-8 gcc-8-base libgcc-8-dev libmpx2 libstdc++-8-dev
0 upgraded, 7 newly installed, 0 to remove and 0 not upgraded.
Need to get 32.8 MB of archives.
After this operation, 115 MB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
Error: building at STEP "RUN scripts/enable_gcc8.sh": while running runtime: exit status 1

```

It's possible to fix `enable_gcc8.sh` itself to avoid this error, but that script is actually not needed on Focal since gcc-9 is the default there.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸🔸
