### PR TITLE
Fix "No space left on device" issue on Github Actions

### DIFF
--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,22 +29,26 @@
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
-  docker build -t gz-citadel-docs -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'fortress' || $1 == 'Fortress' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Fortress\e[0m\e[39m"
-  docker build -t gz-fortress-docs -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'garden' || $1 == 'Garden' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Garden\e[0m\e[39m"
-  docker build -t gz-garden-docs -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'harmonic' || $1 == 'Harmonic' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Harmonic\e[0m\e[39m"
-  docker build -t gz-harmonic-docs -f Dockerfile.harmonic --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -f Dockerfile.harmonic --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image prune -f
 fi
 
 

--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -26,29 +26,10 @@
 # Build the docker container, which also uploads all documentation.
 # We are using docker because a library's documentation links to other
 # library documentation, and we want to guarantee a clean system.
-if [[ $1 == 'acropolis' || $1 == 'Acropolis' ]]; then
-  echo -e "\e[46m\e[30mUploading documentation for Acropolis\e[0m\e[39m"
-  docker build -t gz-acropolis-docs -f Dockerfile.acropolis --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
-fi
-
-if [[ $1 == 'blueprint' || $1 == 'Blueprint' ]]; then
-  echo -e "\e[46m\e[30mUploading documentation for Blueprint\e[0m\e[39m"
-  docker build -t gz-blueprint-docs -f Dockerfile.blueprint --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
-fi
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
   docker build -t gz-citadel-docs -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
-fi
-
-if [[ $1 == 'dome' || $1 == 'Dome' ]]; then
-  echo -e "\e[46m\e[30mUploading documentation for Dome\e[0m\e[39m"
-  docker build -t gz-dome-docs -f Dockerfile.dome --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
-fi
-
-if [[ $1 == 'edifice' || $1 == 'Edifice' ]]; then
-  echo -e "\e[46m\e[30mUploading documentation for Edifice\e[0m\e[39m"
-  docker build -t gz-edifice-docs -f Dockerfile.edifice --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
 fi
 
 if [[ $1 == 'all' || $1 == 'fortress' || $1 == 'Fortress' ]]; then


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Our documentation deployment Action is failing with a "No space left on device" error. I think this is because we're creating docker images for each release, but not removing them even though they're not needed anymore.

This PR also removes EOL releases from the deployment script in 3d884bec62fbe259d18bb15871dcfd3f65ec4b00.

This would be easier to review by commit.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.