### PR TITLE
Fix documentation upload Github Action

### DIFF
--- a/tools/build_docs.sh
+++ b/tools/build_docs.sh
@@ -29,25 +29,29 @@
 
 if [[ $1 == 'all' || $1 == 'citadel' || $1 == 'Citadel' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Citadel\e[0m\e[39m"
-  docker build -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -t gz-docs-builder -f Dockerfile.citadel --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image rm -f gz-docs-builder
   docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'fortress' || $1 == 'Fortress' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Fortress\e[0m\e[39m"
-  docker build -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -t gz-docs-builder -f Dockerfile.fortress --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image rm -f gz-docs-builder
   docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'garden' || $1 == 'Garden' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Garden\e[0m\e[39m"
-  docker build -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -t gz-docs-builder -f Dockerfile.garden --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image rm -f gz-docs-builder
   docker image prune -f
 fi
 
 if [[ $1 == 'all' || $1 == 'harmonic' || $1 == 'Harmonic' ]]; then
   echo -e "\e[46m\e[30mUploading documentation for Harmonic\e[0m\e[39m"
-  docker build -f Dockerfile.harmonic --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker build -t gz-docs-builder -f Dockerfile.harmonic --build-arg GZ_VERSION_PASSWORD --build-arg GZ_VERSION_DATE=`date -Iseconds` --no-cache --build-arg AWS_ACCESS_KEY_ID --build-arg AWS_SECRET_ACCESS_KEY .
+  docker image rm -f gz-docs-builder
   docker image prune -f
 fi
 


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
The documentation upload action keeps failing saying that it's out of space. I attempted to fix this in #390, but that hasn't solved the issue. Here, I'm explicitly removing the docker image instead of just relying on `docker prune`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
