### PR TITLE
Build from source: clarify dependency install step

### DIFF
--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -116,9 +116,10 @@ wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
 sudo apt-get update
 ```
 
-The command below will install all dependencies in Ubuntu:
+The command below must be run from a workspace with the Gazebo source code and will install all dependencies in Ubuntu:
 
 ```bash
+cd ~/workspace/src
 sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```

--- a/fortress/install_ubuntu_src.md
+++ b/fortress/install_ubuntu_src.md
@@ -119,9 +119,10 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 sudo apt-get update
 ```
 
-The command below will install all dependencies in Ubuntu Bionic, Focal or Jammy:
+The command below must be run from a workspace with the Gazebo source code and will install all dependencies in Ubuntu:
 
 ```bash
+cd ~/workspace/src
 sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/ignition\|sdf/d' | tr '\n' ' ')
 ```

--- a/garden/install_ubuntu_src.md
+++ b/garden/install_ubuntu_src.md
@@ -119,9 +119,10 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 sudo apt-get update
 ```
 
-The command below will install all dependencies in Ubuntu:
+The command below must be run from a workspace with the Gazebo source code and will install all dependencies in Ubuntu:
 
 ```bash
+cd ~/workspace/src
 sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 ```

--- a/harmonic/install_ubuntu_src.md
+++ b/harmonic/install_ubuntu_src.md
@@ -119,9 +119,10 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-
 sudo apt-get update
 ```
 
-The command below will install all dependencies in Ubuntu:
+The command below must be run from a workspace with the Gazebo source code and will install all dependencies in Ubuntu:
 
 ```bash
+cd ~/workspace/src
 sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 ```


### PR DESCRIPTION
# 🦟 Bug fix

Clarify in response to this question: https://community.gazebosim.org/t/unable-to-install-gazebo-garden-in-ubuntu-20-04/2296

## Summary

Clarify how to install dependencies when building from source. I've modified the harmonic folder doc only, so this is marked this as a draft; I will propagate the change to the other folders once the wording has been reviewed.

cc @tfoote

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
