### PR TITLE
update osx instructions

### DIFF
--- a/garden/install_osx_src.md
+++ b/garden/install_osx_src.md
@@ -83,7 +83,7 @@ Install all dependencies:
 Dependency for Ogre:
 
 ```bash
-brew cask install xquartz
+brew install xquartz --cask
 ```
 
 General dependencies:

--- a/harmonic/install_osx_src.md
+++ b/harmonic/install_osx_src.md
@@ -81,7 +81,7 @@ Install all dependencies:
 Dependency for Ogre:
 
 ```bash
-brew cask install xquartz
+brew install xquartz --cask
 ```
 
 General dependencies:


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
When following the instructions, I came across:

```
Error: `brew cask` is no longer a `brew` command. Use `brew <command> --cask` instead.
```

this updates the docs accordingly.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.