### PR TITLE
Remove ros-humble-ros-gzharmonic since it's not supported currently

### DIFF
--- a/ros_installation.md
+++ b/ros_installation.md
@@ -315,7 +315,7 @@ other ROS packages that depend on Gazebo-classic.
 |                         | **Gazebo Garden**             | **Gazebo Harmonic (LTS)**   |
 |------------------------ |-----------------------------  | --------------------------  |
 | **ROS 2 Iron**          | `ros-iron-ros-gzgarden`       | `ros-iron-ros-gzharmonic`   |
-| **ROS 2 Humble (LTS)**  | `ros-humble-ros-gzgarden`     | `ros-humble-ros-gzharmonic` |
+| **ROS 2 Humble (LTS)**  | `ros-humble-ros-gzgarden`     |                             |
 
 #### Where I can find the different features implemented on each Gazebo version?
 


### PR DESCRIPTION

# 🦟 Bug fix
We currently do not provide binaries for `ros-humble-ros-gzharmonic`, so removing from documentation.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.