### PR TITLE
Add a comment on get_started for the use of ign in Citadel/Fortress

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -44,7 +44,7 @@ simulator, from a terminal.
 Launch Gazebo by running:
 
 ```
-gz sim shapes.sdf
+gz sim shapes.sdf  # Fortress and Citadel use "ign gazebo" instead of "gz sim"
 ```
 
 This command will launch both the Sim server and Sim GUI with a world
@@ -54,13 +54,13 @@ Add the `-v 4` command line argument to generate error, warning,
 informational, and debugging messages on the console.
 
 ```
-gz sim shapes.sdf -v 4
+gz sim shapes.sdf -v 4  # Fortress and Citadel use "ign gazebo" instead of "gz sim"
 ```
 
 Gazebo Sim can also be run headless, i.e. without the GUI, by using the `-s` (server only) flag.
 
 ```
-gz sim -s shapes.sdf -v 4
+gz sim -s shapes.sdf -v 4  # Fortress and Citadel use "ign gazebo" instead of "gz sim"
 ```
 
 Similarly, the GUI can be run independently using the `-g` (gui only) flag.
@@ -109,12 +109,12 @@ and another for the GUI:
 
 ```sh
 # launch server in one terminal
-gz sim -v 4 shapes.sdf -s
+gz sim -v 4 shapes.sdf -s  # Fortress and Citadel use "ign gazebo" instead of "gz sim"
 ```
 
 ```sh
 # launch gui in a separate terminal
-gz sim -v 4 -g
+gz sim -v 4 -g  # Fortress and Citadel use "ign gazebo" instead of "gz sim"
 ```
 
 The GUI on macOS is currently known to be unstable. Basic interaction with


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The `get_started` page displays the use of some basic commands using `gz sim`. Since the page is shared across all the Gazebo collections I have added a note to the commands to indicate the right way for Citadel/Fortress.

An alternative would be to have a per-collection page but I think that it might not worth the effort of maintain the copies.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
