### PR TITLE
Fix links to README.

### DIFF
--- a/citadel/ros2_integration.md
+++ b/citadel/ros2_integration.md
@@ -6,7 +6,7 @@ from ROS and apply it to Ignition and vice versa.
 
 ## ros_ign_bridge
 
-`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md) to verify if your message type is supported by the bridge.
+`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md) to verify if your message type is supported by the bridge.
 
 ## Requirements
 
@@ -32,7 +32,7 @@ The ROS message type is followed by an `@`, `[`, or `]` symbol where:
 * `[`  is a bridge from Ignition to ROS.
 * `]`  is a bridge from ROS to Ignition.
 
-Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
+Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
 explaining how to make communication connections from ROS to Ignition and vice versa.
 
 ## Publish key strokes to ROS

--- a/dome/ros2_integration.md
+++ b/dome/ros2_integration.md
@@ -6,7 +6,7 @@ from ROS and apply it to Ignition and vice versa.
 
 ## ros_ign_bridge
 
-`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md) to verify if your message type is supported by the bridge.
+`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md) to verify if your message type is supported by the bridge.
 
 ## Requirements
 
@@ -34,7 +34,7 @@ The ROS message type is followed by an `@`, `[`, or `]` symbol where:
 * `[`  is a bridge from Ignition to ROS.
 * `]`  is a bridge from ROS to Ignition.
 
-Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
+Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
 explaining how to make communication connections from ROS to Ignition and vice versa.
 
 ## Publish key strokes to ROS

--- a/edifice/ros2_integration.md
+++ b/edifice/ros2_integration.md
@@ -6,7 +6,7 @@ from ROS and apply it to Ignition and vice versa.
 
 ## ros_ign_bridge
 
-`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md) to verify if your message type is supported by the bridge.
+`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md) to verify if your message type is supported by the bridge.
 
 ## Requirements
 
@@ -34,7 +34,7 @@ The ROS message type is followed by an `@`, `[`, or `]` symbol where:
 * `[`  is a bridge from Ignition to ROS.
 * `]`  is a bridge from ROS to Ignition.
 
-Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
+Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
 explaining how to make communication connections from ROS to Ignition and vice versa.
 
 ## Publish key strokes to ROS

--- a/fortress/ros2_integration.md
+++ b/fortress/ros2_integration.md
@@ -6,7 +6,7 @@ from ROS and apply it to Ignition and vice versa.
 
 ## ros_ign_bridge
 
-`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md) to verify if your message type is supported by the bridge.
+`ros_ign_bridge` provides a network bridge which enables the exchange of messages between ROS 2 and Ignition Transport. Its support is limited to only certain message types. Please, check this [README](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md) to verify if your message type is supported by the bridge.
 
 ## Requirements
 
@@ -32,7 +32,7 @@ The ROS message type is followed by an `@`, `[`, or `]` symbol where:
 * `[`  is a bridge from Ignition to ROS.
 * `]`  is a bridge from ROS to Ignition.
 
-Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_ign_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
+Have a look at these [examples](https://github.com/ignitionrobotics/ros_ign/blob/ros2/ros_gz_bridge/README.md#example-1a-ignition-transport-talker-and-ros-2-listener)
 explaining how to make communication connections from ROS to Ignition and vice versa.
 
 ## Publish key strokes to ROS


### PR DESCRIPTION

# 🦟 Bug fix

Fixes #80

## Summary
In the tutorial [https://gazebosim.org/docs/fortress/ros2_integration](https://gazebosim.org/docs/fortress/ros2_integration) for `Ros 2 Integration Via Bridge` the links used to referance the readme use the ros_ign_bridge shim package name.
The links are broken because they use `ros_ign_bridge` as part of the url which isn't a valid folder,ros_gz_bridge is the right folder.

I fixed the links.
