### PR TITLE
fixed "matix" typo of "matrix" in building_robot.md

### DIFF
--- a/garden/building_robot.md
+++ b/garden/building_robot.md
@@ -119,7 +119,7 @@ We define the first link, the `chassis` of our car and it's pose relative to the
 #### Inertial properties
 
 ```xml
-    <inertial> <!--inertial properties of the link mass, inertia matix-->
+    <inertial> <!--inertial properties of the link mass, inertia matrix-->
         <mass>1.14395</mass>
         <inertia>
             <ixx>0.095329</ixx>


### PR DESCRIPTION
fixed a small typo in the building_robot.md tutorial