### PR TITLE
Upload to ign-gazebo docs to both api/gazebo and api/sim

### DIFF
--- a/tools/scripts/build_gz.sh
+++ b/tools/scripts/build_gz.sh
@@ -42,6 +42,19 @@ if [[ ! -z "$4" && "$4" != "n" ]]; then
   libName=`echo "$2" | grep -oP "(?<=gz-).*"`
   libName="${libName//-/_}"
 
+  majorVersion="${version/\.*/}"
+  # Make sure the majorVersion is a valid number
+  numberCheckRegex='^[0-9]+$'
+  if [[ $majorVersion =~ $numberCheckRegex ]]; then
+    # If this is ign-gazebo (gz-sim < 6), the upload_doc.sh will upload to api/gazebo so we'll need to
+    # sync to api/sim manually
+    if [[ "$libName" == "sim" && "$majorVersion" -le 6 ]]; then
+      aws s3 sync s3://gazebosim.org/api/gazebo/${majorVersion}/ s3://gazebosim.org/api/sim/${majorVersion}/
+    fi
+  else
+    echo "Invalid major version ${majorVersion}"
+  fi
+
   echo -e "\e[46m\e[30mAdding version [$version] for library [$libName], release date [$5]...\e[0m\e[39m"
   curl -k -X POST -d '{"libName":"'"$libName"'", "version":"'"$version"'", "releaseDate":"'"$5"'","password":"'"$6"'"}' https://api.gazebosim.org/1.0/versions
   echo -e "\e[46m\e[30mAdded version [$version] for library [$libName], release date [$5]\e[0m\e[39m"

--- a/tools/scripts/build_gz.sh
+++ b/tools/scripts/build_gz.sh
@@ -46,7 +46,7 @@ if [[ ! -z "$4" && "$4" != "n" ]]; then
   # Make sure the majorVersion is a valid number
   numberCheckRegex='^[0-9]+$'
   if [[ $majorVersion =~ $numberCheckRegex ]]; then
-    # If this is ign-gazebo (gz-sim < 6), the upload_doc.sh will upload to api/gazebo so we'll need to
+    # If this is ign-gazebo (gz-sim <= 6), the upload_doc.sh will upload to api/gazebo so we'll need to
     # sync to api/sim manually
     if [[ "$libName" == "sim" && "$majorVersion" -le 6 ]]; then
       aws s3 sync s3://gazebosim.org/api/gazebo/${majorVersion}/ s3://gazebosim.org/api/sim/${majorVersion}/


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The upload_doc.sh script uploads to s3://gazebosim.org/api/gazebo/ when building gz-sim versions lower than 6 (Fortress). However, our website has links to https://gazebosim.org/api/sim/6/, which are currently outdated (there must have been a manual upload at some point). This fixes the problem by syncing the api/gazebo/${majorVersion} files into the api/sim/${majorVersion} directory.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
