### PR TITLE
contributing.md: suggest multi-repo features target main

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -183,8 +183,14 @@ get acquainted with this development process.
    take place in your fork.
    - An important thing to do is create a remote pointing to the [upstream remote repository](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/configuring-a-remote-for-a-fork). This way, you can always check for modifications on the original repository and **always** keep your fork repository up to date.
 
-1. **Choose a base branch.** If your changes will break API or ABI, then
-   base your new branch off of `main`. If your changes don't break
+1. **Choose a base branch.**
+   - If your changes will break API or ABI, then base your new branch off of `main`.
+   - If you are making interdependent changes to multiple repositories without
+     breaking API or ABI, it is also recommended to base your new branches of of `main`
+     to simplify automated testing of the changes and the review process. Your
+     changes may be backported to an existing release once all the changes
+     have been merged.
+   - If your changes don't break
    API/ABI and you would like them to be released to an existing release
    with major version `N`, then use branch `gz-<library>N` as the base.
 


### PR DESCRIPTION
# 🎉 New feature

Adds recommendation about interdependent multi-repository features

## Summary

I believe we discussed somewhat recently a recommendation to target interdependent multi-repository features to `main` instead of release branches since this simplifies CI / automated testing and pull request review, so I've added that recommendation to our contribution guide.

## Test it

Preview and proofread the changes

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [X] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
