### PR TITLE
Remove gazebo11 side by side install for Ionic

### DIFF
--- a/garden/install_ubuntu.md
+++ b/garden/install_ubuntu.md
@@ -4,10 +4,12 @@ Garden binaries are provided for Ubuntu Focal and Jammy. The
 Garden binaries are hosted in the packages.osrfoundation.org repository.
 To install all of them, the metapackage `gz-garden` can be installed.
 
-**WARNING:** for gazebo-classic (eg. `gazebo11`) users: `gz-garden` cannot be
+<div class="warning">
+WARNING: for gazebo-classic (eg. `gazebo11`) users: `gz-harmonic` cannot be
 installed alongside with `gazebo11` by default. To facilitate the migration
 this can be done using the instruction detailed in
 [Installing Gazebo11 side by side with new Gazebo](/docs/all/install_gz11_side_by_side).
+</div>
 
 First install some necessary tools:
 

--- a/garden/install_ubuntu.md
+++ b/garden/install_ubuntu.md
@@ -5,7 +5,7 @@ Garden binaries are hosted in the packages.osrfoundation.org repository.
 To install all of them, the metapackage `gz-garden` can be installed.
 
 <div class="warning">
-WARNING: for gazebo-classic (eg. `gazebo11`) users: `gz-harmonic` cannot be
+WARNING: for gazebo-classic (eg. `gazebo11`) users: `gz-garden` cannot be
 installed alongside with `gazebo11` by default. To facilitate the migration
 this can be done using the instruction detailed in
 [Installing Gazebo11 side by side with new Gazebo](/docs/all/install_gz11_side_by_side).

--- a/harmonic/install_ubuntu.md
+++ b/harmonic/install_ubuntu.md
@@ -4,10 +4,12 @@ Harmonic binaries are provided for Ubuntu Jammy (22.04) and Ubuntu Noble (24.04)
 Harmonic binaries are hosted in the packages.osrfoundation.org repository.
 To install all of them, the metapackage `gz-harmonic` can be installed.
 
-*WARNING:** for gazebo-classic (eg. `gazebo11`) users: `gz-harmonic` cannot be
+<div class="warning">
+WARNING: for gazebo-classic (eg. `gazebo11`) users: `gz-harmonic` cannot be
 installed alongside with `gazebo11` by default. To facilitate the migration
 this can be done using the instruction detailed in
 [Installing Gazebo11 side by side with new Gazebo](/docs/all/install_gz11_side_by_side).
+</div>
 
 First install some necessary tools:
 

--- a/ionic/install_ubuntu.md
+++ b/ionic/install_ubuntu.md
@@ -4,8 +4,6 @@ Ionic binaries are provided for Ubuntu Jammy (22.04) and Ubuntu Noble (24.04). T
 Ionic binaries are hosted in the packages.osrfoundation.org repository.
 To install all of them, the metapackage `gz-ionic` can be installed.
 
-**WARNING:** `gz-ionic` cannot be installed alongside gazebo-classic (eg. `gazebo11`) since both use the `gz` command line tool. Trying to install `gz-ionic` on a system that already has gazebo-classic installed from binaries will cause gazebo-classic and its dependencies to be uninstalled. Currently, the workarounds for this are to install from source or to use Docker [`gazebo-classic`](https://hub.docker.com/_/gazebo) so they are not installed side-by-side on the same system.
-
 First install some necessary tools:
 
 ```bash


### PR DESCRIPTION
Following up #438. 

Ionic only supports Noble. The PR also implements the nice warning used in the Windows tutorial for Garden and Harmonic.