### PR TITLE
Replace the use of wget by curl in _install docs

### DIFF
--- a/citadel/install_osx_src.md
+++ b/citadel/install_osx_src.md
@@ -55,7 +55,7 @@ All the sources of ignition-citadel are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-citadel.yaml
+curl -O https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-citadel.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Ignition libraries sources from

--- a/citadel/install_ubuntu.md
+++ b/citadel/install_ubuntu.md
@@ -8,7 +8,7 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release wget gnupg
+sudo apt-get install lsb-release gnupg
 ```
 
 Then install Ignition Citadel:
@@ -16,7 +16,7 @@ Then install Ignition Citadel:
 
 ```bash
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+curl https://packages.osrfoundation.org/gazebo.key | sudo apt-key add -
 sudo apt-get update
 sudo apt-get install ignition-citadel
 ```

--- a/citadel/install_ubuntu_src.md
+++ b/citadel/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release gnupg curl
+sudo apt install python3-pip lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip
@@ -90,7 +90,7 @@ All the sources of ignition-citadel are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-citadel.yaml
+curl -O https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-citadel.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Ignition libraries sources from
@@ -112,7 +112,7 @@ Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
-wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
+curl https://packages.osrfoundation.org/gazebo.key | sudo apt-key add -
 sudo apt-get update
 ```
 

--- a/fortress/install_osx_src.md
+++ b/fortress/install_osx_src.md
@@ -55,7 +55,7 @@ All the sources of ignition-fortress are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-fortress.yaml
+curl -O https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-fortress.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Ignition libraries sources from

--- a/fortress/install_ubuntu.md
+++ b/fortress/install_ubuntu.md
@@ -8,14 +8,14 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release wget gnupg
+sudo apt-get install lsb-release gnupg
 ```
 
 Then install Ignition Fortress:
 
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 sudo apt-get install ignition-fortress

--- a/fortress/install_ubuntu.md
+++ b/fortress/install_ubuntu.md
@@ -15,7 +15,7 @@ Then install Ignition Fortress:
 
 
 ```bash
-curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 sudo apt-get install ignition-fortress

--- a/fortress/install_ubuntu_src.md
+++ b/fortress/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release gnupg curl
+sudo apt install python3-pip lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip
@@ -93,7 +93,7 @@ All the sources of ignition-fortress are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-fortress.yaml
+curl -O https://raw.githubusercontent.com/ignition-tooling/gazebodistro/master/collection-fortress.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Ignition libraries sources from
@@ -114,7 +114,7 @@ method to install software dependencies.
 Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 ```

--- a/garden/install_osx_src.md
+++ b/garden/install_osx_src.md
@@ -56,7 +56,7 @@ All the sources of gazebo-garden are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml
+curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Gazebo libraries sources from

--- a/garden/install_ubuntu.md
+++ b/garden/install_ubuntu.md
@@ -15,7 +15,7 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release gnupg
+sudo apt-get install lsb-release curl gnupg
 ```
 
 Then install Gazebo Garden:

--- a/garden/install_ubuntu.md
+++ b/garden/install_ubuntu.md
@@ -15,14 +15,14 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release wget gnupg
+sudo apt-get install lsb-release gnupg
 ```
 
 Then install Gazebo Garden:
 
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 sudo apt-get install gz-garden

--- a/garden/install_ubuntu_src.md
+++ b/garden/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release gnupg curl
+sudo apt install python3-pip lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip
@@ -93,7 +93,7 @@ All the sources of gazebo-garden are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml
+curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-garden.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Gazebo libraries sources from
@@ -114,7 +114,7 @@ method to install software dependencies.
 Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 ```

--- a/harmonic/install_osx_src.md
+++ b/harmonic/install_osx_src.md
@@ -55,7 +55,7 @@ All the sources of gazebo-harmonic are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-harmonic.yaml
+curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-harmonic.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Gazebo libraries sources from

--- a/harmonic/install_ubuntu.md
+++ b/harmonic/install_ubuntu.md
@@ -15,14 +15,14 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release wget gnupg
+sudo apt-get install lsb-release gnupg
 ```
 
 Then install Gazebo Harmonic:
 
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 sudo apt-get install gz-harmonic

--- a/harmonic/install_ubuntu_src.md
+++ b/harmonic/install_ubuntu_src.md
@@ -114,7 +114,7 @@ method to install software dependencies.
 Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
-sudo curl https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 ```

--- a/ionic/install_osx_src.md
+++ b/ionic/install_osx_src.md
@@ -55,7 +55,7 @@ All the sources of gazebo-ionic are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-ionic.yaml
+curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-ionic.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Gazebo libraries sources from

--- a/ionic/install_ubuntu.md
+++ b/ionic/install_ubuntu.md
@@ -8,14 +8,14 @@ First install some necessary tools:
 
 ```bash
 sudo apt-get update
-sudo apt-get install lsb-release wget gnupg
+sudo apt-get install lsb-release gnupg
 ```
 
 Then install Gazebo Ionic:
 
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 sudo apt-get install gz-ionic

--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip wget lsb-release gnupg curl
+sudo apt install python3-pip lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip
@@ -93,7 +93,7 @@ All the sources of gazebo-ionic are declared in a yaml file. Download
 it to the workspace:
 
 ```bash
-wget https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-ionic.yaml
+curl -O https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-ionic.yaml
 ```
 
 Use `vcstool` to automatically retrieve all the Gazebo libraries sources from
@@ -114,7 +114,7 @@ method to install software dependencies.
 Add `packages.osrfoundation.org` to the apt sources list:
 
 ```bash
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 sudo apt-get update
 ```

--- a/tools/scripts/install_common_deps.sh
+++ b/tools/scripts/install_common_deps.sh
@@ -10,17 +10,16 @@ sudo apt-get update
 sudo apt-get install -y \
   gnupg \
   lsb-release \
-  wget
+  curl
 
-sudo wget https://packages.osrfoundation.org/gazebo.gpg -O /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
+sudo curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] https://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
 
 sudo apt-get update
 
 sudo apt-get install -y \
   build-essential \
   cmake \
-  curl \
   doxygen \
   git \
   pkg-config \


### PR DESCRIPTION
There is a bug in the Harmonic instructions by using curl with the option of `-O` which is not the same than `--output` in curl but it is correct if you use grep.  The PR changes all the occurrences of wget in supported _install_* docs to use curl instead of wget.

With curl:
  * `--output <file>` will write output to the <file>
  * -O will write output to a file named the same than the remote file
  * <no args> will write output to stdout.

The PR also change to use https everywhere.