### PR TITLE
Fix/redo API docs generation

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   labeler:
+    if: github.repository_owner == 'gazebosim'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v2

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -63,12 +63,12 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - name: Configure AWS Credentials
-      id: creds
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-region: us-east-1
-        role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
+    # - name: Configure AWS Credentials
+    #   id: creds
+    #   uses: aws-actions/configure-aws-credentials@v4
+    #   with:
+    #     aws-region: us-east-1
+    #     role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
     - uses: actions/download-artifact@v4
       with:
         path: .api-docs
@@ -80,13 +80,13 @@ jobs:
       with:
         name: api-docs
         path: .api-out/*
-    - name: Run nightly upload
-      run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
-      shell: bash
-      env:
-        AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-        AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
-    - name: Invalidate Cloudfront distribution
-      run: |
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1
+    # - name: Run nightly upload
+    #   run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
+    #   shell: bash
+    #   env:
+    #     AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+    #     AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+    #     AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+    # - name: Invalidate Cloudfront distribution
+    #   run: |
+    #     aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test_gazebo:
+  build_api_docs:
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -32,7 +32,7 @@ jobs:
           - docker_image: ubuntu:jammy
             gazebo_distribution: harmonic
     steps:
-      - uses: actions/checkout@v4
+      - uses: ros-tooling/setup-ros@v0.7
       - name: 'Set up Gazebo'
         uses: gazebo-tooling/setup-gazebo@1f55cec330de851fa373f1ade8ac6b7ddfe6f013
         with:

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_api_docs:
+  build:
     name: 'Build API Docs (${{ matrix.gazebo_distribution }})'
     runs-on: ubuntu-latest
     container:
@@ -44,13 +44,22 @@ jobs:
           rm -rf sdformat
           sudo apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
-          colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc
+          colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON -DBUILD_TESTING=OFF --cmake-target doc --packages-up-to-regex gz-math
           mkdir output
-          for d in build/*; do
-            cp -a $d/doxygen/html/* output/$d
+          for d in $(find build -type d -maxdepth 1); do
+            cp -a $d/doxygen/html/* output/$(basename $d)
           done
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.gazebo_distribution }}_api_docs
           path: ws/output
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+    - uses: actions/download-artifact@v4
+    - name: Display structure of downloaded files
+      run: ls -R

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
-        run: sudo apt-get install -y doxygen dot
+        run: sudo apt-get install -y doxygen graphviz
       - name: 'Add missing dependencies'
         run: sudo apt-get install -y libopengl-dev
       - name: 'Build Docs'
@@ -44,6 +44,7 @@ jobs:
           cd ws/src
           vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-${{ matrix.gazebo_distribution}}.yaml
           rm -rf sdformat
+          rm -rf gz-tools
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
           colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON -DBUILD_TESTING=OFF --cmake-target doc

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -76,9 +76,9 @@ jobs:
         pattern: api-docs-*
         merge-multiple: true
     - name: Display structure of downloaded files
-      run: ls -R
+      run: ls -Ra
     - name: 'Restructure API Docs'
-      run: python3 tools/restructure_doxygen_artifacts.py ${{steps.download.output.download-path}} .api-out
+      run: python3 tools/restructure_doxygen_artifacts.py ${{steps.download.outputs.download-path}} .api-out
     - uses: actions/upload-artifact@v4
       with:
         name: api-docs

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -20,8 +20,8 @@ jobs:
           # - ubuntu_distribution: focal
           #   gazebo_distribution: citadel
           #
-          # - ubuntu_distribution: focal
-          #   gazebo_distribution: fortress
+          - ubuntu_distribution: focal
+            gazebo_distribution: fortress
 
           - ubuntu_distribution: focal
             gazebo_distribution: garden
@@ -44,7 +44,7 @@ jobs:
           rm -rf sdformat
           sudo DEBIAN_FRONTEND=noninteractive apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
-          colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON -DBUILD_TESTING=OFF --cmake-target doc --packages-up-to-regex gz-math
+          colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON -DBUILD_TESTING=OFF --cmake-target doc
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -61,5 +61,7 @@ jobs:
         path: api-docs
         pattern: api-docs-*
         merge-multiple: true
-    - name: Display structure of downloaded files
-      run: ls -R
+    - uses: actions/upload-artifact@v4
+      with:
+        name: api-docs-merged
+        path: .

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -42,18 +42,14 @@ jobs:
           cd ws/src
           vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-${{ matrix.gazebo_distribution}}.yaml
           rm -rf sdformat
-          sudo apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
+          sudo DEBIAN_FRONTEND=noninteractive apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
           colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON -DBUILD_TESTING=OFF --cmake-target doc --packages-up-to-regex gz-math
-          mkdir output
-          for d in $(find build -type d -maxdepth 1); do
-            cp -a $d/doxygen/html/* output/$(basename $d)
-          done
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: ${{ matrix.gazebo_distribution }}_api_docs
-          path: ws/output
+          path: ws/build
 
   deploy:
     needs: build

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -39,7 +39,7 @@ jobs:
       - name: 'Install Gazebo recommended packages'
         run: |
           sudo apt-get remove -y gz-${{ matrix.gazebo_distribution}}
-          sudo apt-get install -y --reinstall gz-${{ matrix.gazebo_distribution}}
+          sudo apt-get install -y gz-${{ matrix.gazebo_distribution}}
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,7 +1,6 @@
 name: Deploy API Docs
 
 on:
-  pull_request:
   schedule:
    # UTC timezone
    - cron: '0 6 * * *'
@@ -83,7 +82,7 @@ jobs:
         name: api-docs
         path: .api-out/*
     - name: Run nightly upload
-      run: aws s3 sync --dryrun .api-out/ s3://gazebosim.org/api/
+      run: aws s3 sync .api-out/ s3://gazebosim.org/api/
     - name: Invalidate Cloudfront distribution
       run: |
         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -17,9 +17,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - ubuntu_distribution: focal
-          #   gazebo_distribution: citadel
-          #
+          - ubuntu_distribution: focal
+            gazebo_distribution: citadel
+
           - ubuntu_distribution: focal
             gazebo_distribution: fortress
 
@@ -54,17 +54,39 @@ jobs:
           name: api-docs-${{ matrix.gazebo_distribution }}
           path: ws/build/**/doxygen/html
 
-  deploy:
-    needs: build
+  upload:
+    name: Upload docs to production
     runs-on: ubuntu-latest
-    name: Deploy
+    permissions:
+      id-token: write
+      contents: read
     steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+    - name: Configure AWS Credentials
+      id: creds
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-east-1
+        role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
     - uses: actions/download-artifact@v4
       with:
-        path: api-docs
+        path: .api-docs
         pattern: api-docs-*
         merge-multiple: true
+    - name: 'Restructure API Docs'
+      run: python3 tools/restructure_doxygen_artifacts.py .api-docs .api-out
     - uses: actions/upload-artifact@v4
       with:
-        name: api-docs-merged
-        path: .
+        name: api-docs
+        path: .api-out/*
+    - name: Run nightly upload
+      run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+        AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+    - name: Invalidate Cloudfront distribution
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build_api_docs:
+    name: 'Build API Docs (${{ matrix.gazebo_distribution }})'
     runs-on: ubuntu-latest
     container:
       image: ${{ matrix.docker_image }}
@@ -33,7 +34,7 @@ jobs:
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
-        run: sudo apt install doxygen
+        run: sudo apt install -y doxygen
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,4 +1,4 @@
-name: Upload docs to production
+name: Deploy API Docs
 
 on:
   schedule:
@@ -7,32 +7,40 @@ on:
   workflow_dispatch:
 
 jobs:
-  upload:
-    name: Upload docs to production
-    runs-on: ubuntu-20.04
-    permissions:
-      id-token: write
-      contents: read
+  test_gazebo:
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.docker_image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        gazebo_distribution:
+          - citadel
+          - fortress
+          - garden
+          - harmonic
+        include:
+          - docker_image: ubuntu:focal
+            gazebo_distribution: citadel
+
+          - docker_image: ubuntu:focal
+            gazebo_distribution: fortress
+
+          - docker_image: ubuntu:focal
+            gazebo_distribution: garden
+
+          - docker_image: ubuntu:jammy
+            gazebo_distribution: harmonic
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Configure AWS Credentials
-      id: creds
-      uses: aws-actions/configure-aws-credentials@v4
-      with:
-        aws-region: us-east-1
-        role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
-        # Need to run ./build_docs.sh
-        output-credentials: true
-    - name: Run nightly upload
-      run: |
-        cd tools && ./build_docs.sh all
-      shell: bash
-      env:
-        GZ_VERSION_PASSWORD: ${{ secrets.GZ_VERSION_PASSWORD }}
-        AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-        AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
-    - name: Invalidate Cloudfront distribution
-      run: |
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1
+      - uses: actions/checkout@v4
+      - name: 'Set up Gazebo'
+        uses: gazebo-tooling/setup-gazebo@1f55cec330de851fa373f1ade8ac6b7ddfe6f013
+        with:
+          required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+      - name: 'Build Docs'
+        run: |
+          mkdir -p ws/src
+          cd ws/src
+          vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-${{ matrix.gazebo_distribution}}.yaml
+          cd ..
+          colcon build --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc --packages-skip-regex sdformat

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -56,6 +56,7 @@ jobs:
 
   upload:
     name: Upload docs to production
+    needs: build
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -54,7 +54,6 @@ jobs:
           path: ws/build/**/doxygen/html
 
   deploy:
-    if: always()
     needs: build
     runs-on: ubuntu-latest
     name: Deploy

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -37,7 +37,9 @@ jobs:
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen
       - name: 'Install Gazebo recommended packages'
-        run: sudo apt-get install -y --reinstall gz-${{ matrix.gazebo_distribution}}
+        run: |
+          sudo apt-get remove -y gz-${{ matrix.gazebo_distribution}}
+          sudo apt-get install -y --reinstall gz-${{ matrix.gazebo_distribution}}
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -17,14 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - ubuntu_distribution: ubuntu:focal
+          # - ubuntu_distribution: focal
           #   gazebo_distribution: citadel
           #
-          # - ubuntu_distribution: ubuntu:focal
+          # - ubuntu_distribution: focal
           #   gazebo_distribution: fortress
 
-          # - ubuntu_distribution: ubuntu:focal
-          #   gazebo_distribution: garden
+          - ubuntu_distribution: focal
+            gazebo_distribution: garden
 
           - ubuntu_distribution: jammy
             gazebo_distribution: harmonic
@@ -45,3 +45,12 @@ jobs:
           sudo apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
           colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc
+          mkdir output
+          for d in build/*; do
+            cp -a $d/doxygen/html/* output/$d
+          done
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ${{ matrix.gazebo_distribution }}_api_docs
+          path: ws/output

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -36,10 +36,9 @@ jobs:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen
-      - name: 'Install Gazebo recommended packages'
+      - name: 'Install missing packages'
         run: |
-          sudo apt-get remove -y gz-${{ matrix.gazebo_distribution}}
-          sudo apt-get install -y gz-${{ matrix.gazebo_distribution}}
+          sudo apt-get install -y libfreeimage-dev
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -1,6 +1,7 @@
 name: Deploy API Docs
 
 on:
+  pull_request:
   schedule:
    # UTC timezone
    - cron: '0 6 * * *'

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -12,21 +12,21 @@ jobs:
     name: 'Build API Docs (${{ matrix.gazebo_distribution }})'
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.docker_image }}
+      image: ubuntu:${{ matrix.ubuntu_distribution }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # - docker_image: ubuntu:focal
+          # - ubuntu_distribution: ubuntu:focal
           #   gazebo_distribution: citadel
           #
-          # - docker_image: ubuntu:focal
+          # - ubuntu_distribution: ubuntu:focal
           #   gazebo_distribution: fortress
 
-          # - docker_image: ubuntu:focal
+          # - ubuntu_distribution: ubuntu:focal
           #   gazebo_distribution: garden
 
-          - docker_image: ubuntu:jammy
+          - ubuntu_distribution: jammy
             gazebo_distribution: harmonic
     steps:
       - uses: ros-tooling/setup-ros@v0.7
@@ -36,14 +36,12 @@ jobs:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen
-      - name: 'Install missing packages'
-        run: |
-          sudo apt-get install -y libfreeimage-dev
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src
           cd ws/src
           vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-${{ matrix.gazebo_distribution}}.yaml
           rm -rf sdformat
+          sudo apt-get -y install $(sort -u $(find . -iname 'packages-'${{ matrix.ubuntu_distribution}}'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | tr '\n' ' ')
           cd ..
           colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.gazebo_distribution }}_api_docs
+          name: api-docs-${{ matrix.gazebo_distribution }}
           path: ws/build/**/doxygen/html
 
   deploy:
@@ -58,6 +58,8 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        pattern: *_api_docs
+        path: api-docs
+        pattern: api-docs-*
+        merge-multiple: true
     - name: Display structure of downloaded files
       run: ls -R

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -35,7 +35,9 @@ jobs:
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
-        run: sudo apt-get install -y doxygen
+        run: sudo apt-get install -y doxygen dot
+      - name: 'Add missing dependencies'
+        run: sudo apt-get install -y libopengl-dev
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src
@@ -52,6 +54,7 @@ jobs:
           path: ws/build/**/doxygen/html
 
   deploy:
+    if: always()
     needs: build
     runs-on: ubuntu-latest
     name: Deploy

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -64,33 +64,31 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    # - name: Configure AWS Credentials
-    #   id: creds
-    #   uses: aws-actions/configure-aws-credentials@v4
-    #   with:
-    #     aws-region: us-east-1
-    #     role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
+    - name: Configure AWS Credentials
+      id: creds
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-region: us-east-1
+        role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
     - uses: actions/download-artifact@v4
       id: download
       with:
         path: .api-docs
         pattern: api-docs-*
         merge-multiple: true
-    - name: Display structure of downloaded files
-      run: ls -Ra
     - name: 'Restructure API Docs'
       run: python3 tools/restructure_doxygen_artifacts.py ${{steps.download.outputs.download-path}} .api-out
     - uses: actions/upload-artifact@v4
       with:
         name: api-docs
         path: .api-out/*
-    # - name: Run nightly upload
-    #   run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
-    #   shell: bash
-    #   env:
-    #     AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-    #     AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-    #     AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
-    # - name: Invalidate Cloudfront distribution
-    #   run: |
-    #     aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1
+    - name: Run nightly upload
+      run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
+      shell: bash
+      env:
+        AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
+        AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
+        AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+    - name: Invalidate Cloudfront distribution
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -70,12 +70,15 @@ jobs:
     #     aws-region: us-east-1
     #     role-to-assume: arn:aws:iam::200670743174:role/github-oidc-deployment-gz-web-app
     - uses: actions/download-artifact@v4
+      id: download
       with:
         path: .api-docs
         pattern: api-docs-*
         merge-multiple: true
+    - name: Display structure of downloaded files
+      run: ls -R
     - name: 'Restructure API Docs'
-      run: python3 tools/restructure_doxygen_artifacts.py .api-docs .api-out
+      run: python3 tools/restructure_doxygen_artifacts.py ${{steps.download.output.download-path}} .api-out
     - uses: actions/upload-artifact@v4
       with:
         name: api-docs

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -44,5 +44,6 @@ jobs:
           mkdir -p ws/src
           cd ws/src
           vcs import --input https://raw.githubusercontent.com/gazebo-tooling/gazebodistro/master/collection-${{ matrix.gazebo_distribution}}.yaml
+          rm -rf sdformat
           cd ..
-          colcon build --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc --packages-skip-regex sdformat
+          colcon build --merge-install --event-handlers console_cohesion+ --cmake-args -DBUILD_DOCS=ON --cmake-target doc

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -23,8 +23,8 @@ jobs:
           # - docker_image: ubuntu:focal
           #   gazebo_distribution: fortress
 
-          - docker_image: ubuntu:focal
-            gazebo_distribution: garden
+          # - docker_image: ubuntu:focal
+          #   gazebo_distribution: garden
 
           - docker_image: ubuntu:jammy
             gazebo_distribution: harmonic
@@ -35,7 +35,9 @@ jobs:
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
       - name: 'Add Doxygen'
-        run: sudo apt install -y doxygen
+        run: sudo apt-get install -y doxygen
+      - name: 'Install Gazebo recommended packages'
+        run: sudo apt-get install -y --reinstall gz-${{ matrix.gazebo_distribution}}
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -49,7 +49,7 @@ jobs:
         if: always()
         with:
           name: ${{ matrix.gazebo_distribution }}_api_docs
-          path: ws/build
+          path: ws/build/**/doxygen/html
 
   deploy:
     needs: build
@@ -57,5 +57,7 @@ jobs:
     name: Deploy
     steps:
     - uses: actions/download-artifact@v4
+      with:
+        pattern: *_api_docs
     - name: Display structure of downloaded files
       run: ls -R

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -83,12 +83,7 @@ jobs:
         name: api-docs
         path: .api-out/*
     - name: Run nightly upload
-      run: aws s3 sync --dry-run .api-out/ s3://gazebosim.org/api/
-      shell: bash
-      env:
-        AWS_ACCESS_KEY_ID: ${{ steps.creds.outputs.aws-access-key-id }}
-        AWS_SECRET_ACCESS_KEY: ${{ steps.creds.outputs.aws-secret-access-key }}
-        AWS_SESSION_TOKEN: ${{ steps.creds.outputs.aws-session-token }}
+      run: aws s3 sync --dryrun .api-out/ s3://gazebosim.org/api/
     - name: Invalidate Cloudfront distribution
       run: |
         aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths '/*' --region us-east-1

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -14,17 +14,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gazebo_distribution:
-          - citadel
-          - fortress
-          - garden
-          - harmonic
         include:
-          - docker_image: ubuntu:focal
-            gazebo_distribution: citadel
-
-          - docker_image: ubuntu:focal
-            gazebo_distribution: fortress
+          # - docker_image: ubuntu:focal
+          #   gazebo_distribution: citadel
+          #
+          # - docker_image: ubuntu:focal
+          #   gazebo_distribution: fortress
 
           - docker_image: ubuntu:focal
             gazebo_distribution: garden
@@ -37,6 +32,8 @@ jobs:
         uses: gazebo-tooling/setup-gazebo@1f55cec330de851fa373f1ade8ac6b7ddfe6f013
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+      - name: 'Add Doxygen'
+        run: sudo apt install doxygen
       - name: 'Build Docs'
         run: |
           mkdir -p ws/src

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,6 +6,7 @@ on:
 name: Ticket opened
 jobs:
   assign:
+    if: github.repository_owner == 'gazebosim'
     name: Add ticket to inbox
     runs-on: ubuntu-latest
     steps:

--- a/tools/restructure_doxygen_artifacts.py
+++ b/tools/restructure_doxygen_artifacts.py
@@ -1,0 +1,56 @@
+# Usage
+#   /restructure_doxygen_artifacts.py <path_to_artifacts> <output_directory>
+#
+# Given a directory containing merged doxygen build artifacts, this script reorganizes them so they
+# can be deployed to the website
+# This assumes the following directory structure:
+#   ignition-utils1
+#     doxygen
+#       html
+#   gz-utils2
+#     doxygen
+#       html
+#   ignition-math6
+#     doxygen
+#       html
+#   gz-math7
+#     doxygen
+#       html
+#   ...
+#
+#   The result should look like
+#   utils
+#     1 (content of ignition-utils1/doxygen/html)
+#     2 (content of gz-utils2/doxygen/html)
+#   math
+#     6 (content of ignition-math6/doxygen/html)
+#     7 (content of gz-math7/doxygen/html)
+
+import re
+import sys
+import pathlib
+import shutil
+
+input_dir = pathlib.Path(sys.argv[1])
+output_dir = pathlib.Path(sys.argv[2])
+output_dir.mkdir(exist_ok=True)
+
+re_expr = R"(ignition|gz)-([a-z_]*)(\d*)"
+
+
+def copy_library(lib_html, lib_name, lib_version):
+    output_lib_dir = output_dir / lib_name / lib_version
+    output_lib_dir.mkdir(exist_ok=True, parents=True)
+    print(f"{lib_html} -> {output_lib_dir}")
+    shutil.copytree(lib_html, output_lib_dir, dirs_exist_ok=True)
+
+
+for lib in input_dir.iterdir():
+    m = re.match(re_expr, lib.name)
+    if m:
+        _, lib_name, lib_version = m.groups()
+        lib_html = lib/"doxygen"/"html"
+        copy_library(lib_html, lib_name, lib_version)
+        # Handle gazebo->sim rename by making a copy into the sim directory
+        if lib_name == "gazebo":
+            copy_library(lib_html, "sim", lib_version)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This is both a fix and a redo of our API doc generation in preparation for #441. As of #450, the jobs that generate the API docs have been failing with the following error:

```
2024-06-14T06:21:57.2623277Z #10 37.38 sudo ./aws/install
2024-06-14T06:21:57.9339362Z #10 38.21 You can now run: /usr/local/bin/aws --version
2024-06-14T06:21:58.0848240Z #10 38.21 
2024-06-14T06:21:58.0849021Z #10 38.21 # Configure AWS so that API docs can be uploaded to s3.
2024-06-14T06:21:58.0849924Z #10 38.21 aws configure set aws_access_key_id $1
2024-06-14T06:21:58.3793718Z #10 38.65 aws configure set aws_secret_access_key $2
2024-06-14T06:21:58.8300383Z #10 39.11 aws configure set aws_session_token $3
2024-06-14T06:21:59.2276112Z #10 39.50 
2024-06-14T06:21:59.2277284Z #10 39.50 usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
2024-06-14T06:21:59.2278178Z #10 39.50 To see help text, you can run:
2024-06-14T06:21:59.2278735Z #10 39.50 
2024-06-14T06:21:59.2279090Z #10 39.50   aws help
2024-06-14T06:21:59.2279503Z #10 39.50   aws <command> help
2024-06-14T06:21:59.2280025Z #10 39.50   aws <command> <subcommand> help
2024-06-14T06:21:59.2280548Z #10 39.50 
2024-06-14T06:21:59.2281086Z #10 39.50 aws: error: the following arguments are required: value
2024-06-14T06:21:59.2281774Z #10 39.50 
2024-06-14T06:22:02.4495312Z #10 ERROR: process "/bin/sh -c scripts/install_common_deps.sh $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY $AWS_SESSION_TOKEN" did not complete successfully: exit code: 252
```

Unfortunately, this is not apparent from looking at https://github.com/gazebosim/docs/actions. I only found out because I was comparing run times with the approach in this PR vs our previous approach and the runtimes after #450 were dramatically reduced.

This also reworks how we generate the docs. Instead of docker files that build the documentation, it uses the containers provided by Github actions. This should overcome the #390 issue we've ran into before. It also uses our new gazebo-setup GitHub action making it possible to build the API docs in parallel bringing the build times to ~5 minutes from ~60 minutes.

Finally, this PR will be used in #441 to deploy the API docs along with the gazebosim.org website.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
