### PR TITLE
sensors.md: fix code block

### DIFF
--- a/harmonic/sensors.md
+++ b/harmonic/sensors.md
@@ -30,6 +30,7 @@ When adding a `plugin` to an SDF file which does not currently contain one, the 
     </plugin>
 
     <!-- ... -->
+```
 
 ## IMU sensor
 


### PR DESCRIPTION
## Summary
The harmonic version of the sensors tutorial was formatted improperly, causing unformatted markdown text to be displayed inside of a code block.