### PR TITLE
Fix canonical link generated by sphinx

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -32,7 +32,7 @@ from sphinx.config import Config
 sys.path.append(str(Path(__file__).parent))
 from base_conf import *  # noqa
 
-html_baseurl = f"{html_context['deploy_url']}/docs/latest"  # noqa
+html_baseurl = f"{html_context['deploy_url']}/docs/latest/"  # noqa
 
 html_context.update({
     "github_user": "gazebosim",


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
A trailing slash is necessary for page links to be appended correctly. Currently, for example, https://gazebosim.org/docs/harmonic/sensors/ has the canonical link set to https://gazebosim.org/docs/latestsensors/ instead of https://gazebosim.org/docs/latest/sensors/


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.