### PR TITLE
Use an admonition instead of custom html in get_started.md

### DIFF
--- a/get_started.md
+++ b/get_started.md
@@ -7,10 +7,9 @@ simulation using Gazebo.
 
 ## Step 1: Install
 
-<div class="warning">
-  <strong>Note:</strong> If you are a <a href="https://ros.org">ROS</a> user, please first read our tutorial about
-  the <a href="/docs/latest/ros_installation">ROS/Gazebo installation</a>.
-</div>
+:::{important}
+If you are a [ROS](https://ros.org) user, please first read our tutorial on [ROS/Gazebo installation](ros_installation)
+:::
 
 The recommended installation for new users is the use of binary
 packages available for the platform to use:


### PR DESCRIPTION
Admonitions are now available as of #441. The list of available admonitions can be found on https://myst-parser.readthedocs.io/en/stable/syntax/admonitions.html