### PR TITLE
Add note about libEGL warnings

### DIFF
--- a/harmonic/troubleshooting.md
+++ b/harmonic/troubleshooting.md
@@ -189,6 +189,18 @@ XWayland by unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
 env -u WAYLAND_DISPLAY gz sim -v 4 shapes.sdf
 ```
 
+### EGL warnings
+
+On startup, Gazebo prints out EGL warning messages like the one below:
+
+```
+libEGL warning: DRI2: failed to create dri screen
+```
+
+This message is printed out by Ogre 2 on initialization when it enumerates
+through devices to query for EGL support. The warning is fine to ignore. Gazebo
+should continue to operate without any issues.
+
 
 ## Windows
 

--- a/ionic/troubleshooting.md
+++ b/ionic/troubleshooting.md
@@ -169,20 +169,38 @@ If that loads, you can continue to use Gazebo with Ogre 1, just use the
 
 ### Wayland issues
 
-For users on Wayland, you will need to make sure Gazebo is launched with
-XWayland.
-
-If you see an error message like the one below:
+There's an issue with the interaction of Ogre and Qt in Gazebo that prevents wayland from
+working properly. You might see an error message like the one below:
 
 ```
 Unable to create the rendering window: OGRE EXCEPTION(3:RenderingAPIException): currentGLContext was specified with no current GL context in GLXWindow::create at ./RenderSystems/GL3Plus/src/windowing/GLX/OgreGLXWindow.cpp (line 165)
 ```
 
-try unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
+A workaround is to set `QT_QPA_PLATFORM=xcb`. e.g.:
+
+```
+QT_QPA_PLATFORM=xcb gz sim -v 4 shapes.sdf
+```
+
+Another workaround to try is to make sure Gazebo is launched with
+XWayland by unsetting the `WAYLAND_DISPLAY` environment variable, e.g.
 
 ```sh
 env -u WAYLAND_DISPLAY gz sim -v 4 shapes.sdf
 ```
+
+### EGL warnings
+
+On startup, Gazebo prints out EGL warning messages like the one below:
+
+```
+libEGL warning: DRI2: failed to create dri screen
+```
+
+This message is printed out by Ogre 2 on initialization when it enumerates
+through devices to query for EGL support. The warning is fine to ignore. Gazebo
+should continue to operate without any issues.
+
 
 ## Windows
 


### PR DESCRIPTION
The warning is misleading and we see issues quoting this warning. Ideally we get rid of that message but seems to be difficult to do from downstream library at runtime (currently a compile time flag) as mentioned in https://github.com/gazebosim/gz-rendering/issues/587#issuecomment-1079551561. For now, we add a note on this in troubleshooting guide.

I also ported https://github.com/gazebosim/docs/pull/468 from harmonic to ionic's troubleshooting guide.
