### PR TITLE
Fix sidebar menu spacing on small screens

### DIFF
--- a/_static/css/gazebo.css
+++ b/_static/css/gazebo.css
@@ -90,9 +90,10 @@ header.navbar {
 }
 
 .bd-sidebar-primary {
-  max-height: calc(100vh - var(--pst-header-height) + var(--gz-doc-header-height));
+  max-height: calc(100vh - var(--pst-header-height) - var(--gz-doc-header-height));
   top: calc(var(--pst-header-height) + var(--gz-doc-header-height));
   background-color: var(--gz-color-primary-sidebar);
+  padding-top: 1em;
 }
 
 .bd-sidebar-secondary {


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

This fixes a spacing issue on the sidebar menu where some menu items were not visible on small screens.

The two pictures below show the problem. In the "Before" picture, not that "Fuel" and "Library Reference" are not visible at the bottom of the menu.

**Before**
![image](https://github.com/user-attachments/assets/80ec04e0-2046-4bee-a4e3-605d4d27b6f4)

**After**
![image](https://github.com/user-attachments/assets/63f4c836-0c38-4a98-a959-1a1355d52bec)



## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
