### PR TITLE
Build Ionic API docs

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -36,6 +36,7 @@ jobs:
         uses: gazebo-tooling/setup-gazebo@1f55cec330de851fa373f1ade8ac6b7ddfe6f013
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
+          use-gazebo-nightly: ${{ matrix.gazebo_distribution == 'ionic'}}
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen graphviz
       - name: 'Add missing dependencies'

--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -27,6 +27,9 @@ jobs:
 
           - ubuntu_distribution: jammy
             gazebo_distribution: harmonic
+
+          - ubuntu_distribution: noble
+            gazebo_distribution: ionic
     steps:
       - uses: ros-tooling/setup-ros@v0.7
       - name: 'Set up Gazebo'


### PR DESCRIPTION
Enables API doc generation. It was necessary to set `use-gazebo-nighly` since it tries to install `gz-ionic`.

Needs https://github.com/gazebosim/gz-transport/pull/512