### PR TITLE
Update supported platforms in Ionic

### DIFF
--- a/ionic/install.md
+++ b/ionic/install.md
@@ -54,10 +54,9 @@ This list may change up to the release date.
 
 These are the **officially** supported platforms:
 
-* Ubuntu Jammy on amd64
 * Ubuntu Noble on amd64
 
 Platforms supported at **best-effort** include arm architectures, Windows and
 macOS. See
-[this ticket](https://github.com/gazebo-tooling/release-tools/issues/597)
+[this ticket](https://github.com/gazebo-tooling/release-tools/issues/1158)
 for the full status.


### PR DESCRIPTION
Removes Jammy from the list of officially supported platforms.