### PR TITLE
Correct supported versions for ROS 2 Rolling in distro table

### DIFF
--- a/ros_installation.md
+++ b/ros_installation.md
@@ -39,12 +39,12 @@ continued use.
 
 |                           | **GZ Citadel (LTS)**  | **GZ Fortress (LTS)**   | **GZ Garden**   | **GZ Harmonic (LTS)**   |
 |---------------------------|---------------------- |-----------------------  |---------------  | ----------------------  |
-| **ROS 2 Jazzy (LTS)**     | ❌                    | ❌                      | ⚡              | ✅                      |
-| **ROS 2 Rolling**         | ❌                    | ✅                      | ⚡              | ⚡                      |
-| **ROS 2 Iron**            | ❌                    | ✅                      | ⚡              | ⚡                      |
-| **ROS 2 Humble (LTS)**    | ❌                    | ✅                      | ⚡              | ⚡                      |
+| **ROS 2 Jazzy (LTS)**     | ❌                    | ❌                      | ⚡               | ✅                      |
+| **ROS 2 Rolling**         | ❌                    | ❌                      | ⚡               | ✅                      |
+| **ROS 2 Iron**            | ❌                    | ✅                      | ⚡               | ⚡                       |
+| **ROS 2 Humble (LTS)**    | ❌                    | ✅                      | ⚡               | ⚡                       |
 | **ROS 2 Foxy (LTS)**      | ✅                    | ❌                      | ❌              | ❌                      |
-| **ROS 1 Noetic (LTS)**    | ✅                    | ⚡                      | ❌              | ❌                      |
+| **ROS 1 Noetic (LTS)**    | ✅                    | ⚡                       | ❌              | ❌                      |
 
 
 * ✅ - Recommended combination


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #474

## Summary
This PR corrects the supported ROS 2 Rolling version to be Harmonic instead of Fortress.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.