### PR TITLE
Update instructions on checking if sim runs with ogre 1.x

### DIFF
--- a/citadel/troubleshooting.md
+++ b/citadel/troubleshooting.md
@@ -82,9 +82,9 @@ You can also check your OpenGL version running:
     glxinfo | grep "OpenGL version"
 
 You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+that's working by running with Ogre 1 instead of Ogre 2, such as:
 
-    ign gazebo -v 3 lights.sdf
+    ign gazebo -v 3 shapes.sdf --render-engine ogre
 
 If that loads, you can continue to use Ignition with Ogre 1, just use the
 `--render-engine ogre` option.
@@ -102,5 +102,5 @@ https://github.com/osrf/ogre-2.1-release
 ### Ignition crashes when an actor is added to the world
 
 If you are trying to spawn an actor in your environment and you get an error like `Assertion !pos.isNan() && "Invalid vector supplied as parameter"`
-means you are passing nan values to ogre. 
+means you are passing nan values to ogre.
 To fix this you need to do `export LC_NUMERIC="C"` before running ign gazebo.

--- a/fortress/troubleshooting.md
+++ b/fortress/troubleshooting.md
@@ -158,9 +158,9 @@ be co-installable with Ogre 1.x. The code can be found here:
 https://github.com/osrf/ogre-2.2-release
 
 You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+that's working by running with Ogre 1 instead of Ogre 2, such as:
 
-    ign gazebo -v 3 lights.sdf
+    ign gazebo -v 3 shapes.sdf --render-engine ogre
 
 If that loads, you can continue to use Ignition with Ogre 1, just use the
 `--render-engine ogre` option.

--- a/garden/troubleshooting.md
+++ b/garden/troubleshooting.md
@@ -161,9 +161,9 @@ be co-installable with Ogre 1.x. The code can be found here:
 https://github.com/osrf/ogre-2.3-release
 
 You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+that's working by running with Ogre 1 instead of Ogre 2, such as:
 
-    gz sim -v 3 lights.sdf
+    gz sim -v 3 shapes.sdf --render-engine ogre
 
 If that loads, you can continue to use Gazebo with Ogre 1, just use the
 `--render-engine ogre` option.

--- a/harmonic/troubleshooting.md
+++ b/harmonic/troubleshooting.md
@@ -160,9 +160,9 @@ be co-installable with Ogre 1.x. The code can be found here:
 https://github.com/osrf/ogre-2.3-release
 
 You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+that's working by running with Ogre 1 instead of Ogre 2, such as:
 
-    gz sim -v 3 lights.sdf
+    gz sim -v 3 shapes.sdf --render-engine ogre
 
 If that loads, you can continue to use Gazebo with Ogre 1, just use the
 `--render-engine ogre` option.

--- a/ionic/troubleshooting.md
+++ b/ionic/troubleshooting.md
@@ -160,9 +160,9 @@ be co-installable with Ogre 1.x. The code can be found here:
 https://github.com/osrf/ogre-2.3-release
 
 You should be able to use Ogre 1 without any issues however. You can check if
-that's working by running a world which uses Ogre 1 instead of Ogre 2, such as:
+that's working by running with Ogre 1 instead of Ogre 2, such as:
 
-    gz sim -v 3 lights.sdf
+    gz sim -v 3 shapes.sdf --render-engine ogre
 
 If that loads, you can continue to use Gazebo with Ogre 1, just use the
 `--render-engine ogre` option.


### PR DESCRIPTION

# 🦟 Bug fix


## Summary

The instructions for checking if sim runs with ogre 1.x is outdated. The `lights.sdf` world used to have gui configurations to use the `ogre` render engine but that was removed in https://github.com/gazebosim/gz-sim/pull/278. Now the user has to explicitly specify the `--render-engine ogre` arg to run with ogre 1.x. 

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
