### PR TITLE
Use a PIP workspace for colcon and vcs

### DIFF
--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -29,32 +29,17 @@ sudo apt install python3-pip lsb-release gnupg curl
 
 ## vcstool and colcon from pip
 
-PIP is available on all platforms:
+PIP is available on all platforms. Using a PIP workspace to install the tools:
 
 ```bash
-pip install vcstool || pip3 install vcstool
+python3 -m venv $HOME/vcs_colcon_installation
+. $HOME/vcs_colcon_installation/bin/activate
+pip3 install vcstool colcon-common-extensions
 ```
 
-```bash
-pip install -U colcon-common-extensions || pip3 install -U colcon-common-extensions
-```
-
-Check that no errors were printed while installing with PIP. If your system is not recognising the commands, and you're using a system that is compatible with Debian or Ubuntu packages, see the instructions below to install using `apt`.
-
-After installing `vcstool` and `colcon` with PIP, you may need to add their executables to your `$PATH`.
-Check where the installation of these packages took place:
-
-```bash
-pip show vcstool || pip3 show vcstool | grep Location
-
-pip show colcon-common-extensions || pip3 show colcon-common-extensions | grep Location
-```
-
-If your install path is prefixed with `$HOME/.local`, you'll probably need to add the executables within this directory to your `$PATH` in order to avoid "command not found" errors when using `vcstool` and `colcon` later on:
-
-```bash
-export PATH=$PATH:$HOME/.local/bin/
-```
+`vcs` and `colcon` are now available from the PIP workspace in the current
+terminal. For using them in other terminals run the `activate` script as
+done above.
 
 ## vcstool and colcon from apt
 


### PR DESCRIPTION
# 🦟 Bug fix

Related to https://github.com/gazebosim/gazebo_test_cases/issues/1699#issuecomment-2323393555 

## Summary
Remove a good bunch of pip instructions in favor of using a workspace with a simplification of the installation.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.