### PR TITLE
Fix use of upload-artifact action in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           name: website
           path: dist
+          if-no-files-found: 'error'
 
       # Build Docs
   build_docs:
@@ -67,6 +68,7 @@ jobs:
         with:
           name: docs
           path: .build
+          if-no-files-found: 'error'
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
           name: website
           path: dist
           if-no-files-found: 'error'
+          include-hidden-files: 'true'
 
       # Build Docs
   build_docs:
@@ -69,6 +70,7 @@ jobs:
           name: docs
           path: .build
           if-no-files-found: 'error'
+          include-hidden-files: 'true'
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The `deploy` workflow has been silently failing since `upload-artifact` Action has been updated to include a new parameter `include-hidden-files` (see https://github.com/actions/upload-artifact/issues/602). The first commit of this PR sets the parameter `if-no-files-found` to `error` so that the workflow fails if no files were uploaded. The second commit fixes the actual problem by setting `include-hidden-files=true`.

- Failing job: https://github.com/gazebosim/docs/actions/runs/10705065247/job/29679540721?pr=496

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
