### PR TITLE
ionic/install_windows_src: Added protobuf dependency

### DIFF
--- a/ionic/install_windows_src.md
+++ b/ionic/install_windows_src.md
@@ -65,7 +65,7 @@ without any failures when using their functionalities.
    conda install cmake git vcstool curl pkg-config ^
    colcon-common-extensions dartsim eigen freeimage gdal gts ^
    glib dlfcn-win32 ffmpeg ruby tinyxml2 tinyxml ^
-   libprotobuf urdfdom zeromq cppzmq ogre=1.10 ogre-next jsoncpp ^
+   protobuf urdfdom zeromq cppzmq ogre=1.10 ogre-next jsoncpp ^
    libzip qt pybind11 --channel conda-forge
    ```
    This can take tens of minutes (or less when using libmamba solver).


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1545

## Summary
Python bindings need `protobuf` conda package.

Please note that libprotobuf is currently already available in version 5.x, while protobuf only in version 4.x. So this PR downgrades libprotobuf to 4.x, too. But I was able to successfully build Gazebo with libprotobuf 4.x.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.