### PR TITLE
Prepare for Ionic release

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -105,7 +105,7 @@ releases:
   - name: ionic
     lts: false
     eol: false
-    dev: true
+    preferred: true # Only one preferred=true is allowed
     description: Supported Sep, 2024 to Sep, 2026
     libraries:
       - name: cmake
@@ -143,7 +143,6 @@ releases:
   - name: harmonic
     lts: true
     eol: false
-    preferred: true # Only one preferred=true is allowed
     description: Supported Sep, 2023 to Sep, 2028
     libraries:
       - name: cmake


### PR DESCRIPTION
This removes the warning that Ionic is still in development and sets it as the preferred release which makes `latest` and `all` link to Ionic.

**Do not merge till Monday**
