### PR TITLE
Mark Jetty as being under development

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -115,6 +115,7 @@ pages:
 releases:
   - name: jetty
     lts: true
+    dev: true
     eol: false
     preferred: false # Only one preferred=true is allowed
     description: Upcoming release, under development.


### PR DESCRIPTION
The Jetty page currently shows that Jetty is an old version:

![image](https://github.com/user-attachments/assets/d3488755-040c-4f82-862f-d30e0900487d)


With this update:

![image](https://github.com/user-attachments/assets/6af8581d-2230-4684-b1b3-09062adee837)
