### PR TITLE
Fix wrong links in Gazebo Jetty Roadmap

### DIFF
--- a/roadmap.md
+++ b/roadmap.md
@@ -12,9 +12,9 @@ info@openrobotics.org.
   * [Make doxygen tutorials from each library accessible on the main tutorials page on gazebosim.org/docs](https://github.com/gazebosim/docs/issues/55)
   * Copy/adapt tutorials from <https://classic.gazebosim.org/tutorials>
 * [Migrate from Qt5 to Qt6](https://github.com/gazebosim/gz-gui/issues/586)
-* [Use Zenoh in gz-transport](https://github.com/gazebosim/gz-sim/issues/1995)
+* [Use Zenoh in gz-transport](https://github.com/gazebosim/gz-transport/issues/559)
 * [Create or improve interfaces for doing Reinforcement Learning using Gazebo](https://github.com/gazebosim/gz-sim/issues/2662)
-* [Create a federated third party plugin ecosystem](https://github.com/gazebosim/gz-transport/issues/559)
+* [Create a federated third party plugin ecosystem](https://github.com/gazebosim/gz-sim/issues/1995)
 * [Command line: use binaries instead of shared libraries](https://github.com/gazebosim/gz-tools/issues/7)
 * [Download Fuel models on the background](https://github.com/gazebosim/gz-sim/issues/1260)
 * [Support Bazel for all Gazebo libraries](https://github.com/gazebosim/rules_gazebo)


### PR DESCRIPTION

# 🦟 Bug fix

Fixes two wrong links in Gazebo Jetty Roadmap

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

