### PR TITLE
Add Google Analytics

### DIFF
--- a/base_conf.py
+++ b/base_conf.py
@@ -34,6 +34,7 @@ extensions = [
     "myst_parser",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinxcontrib.googleanalytics",
     # 'sphinx_sitemap',
 ]
 
@@ -100,3 +101,5 @@ html_sidebars = {"**": ["gz-sidebar-nav"]}
 html_context = {
     "deploy_url":  os.environ.get("GZ_DEPLOY_URL", "")
 }
+
+googleanalytics_id = "G-JKS50SX85K"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sphinx
 sphinx-copybutton
 sphinx-design
 requests
+sphinxcontrib-googleanalytics


### PR DESCRIPTION
Google Analytics is already set up on Gazebosim.org, but it wasn't enabeled when we transitioned to sphinx for `/docs`.