### PR TITLE
Add venv as a dependency since the following step needs it.

### DIFF
--- a/harmonic/install_ubuntu_src.md
+++ b/harmonic/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip lsb-release gnupg curl
+sudo apt install python3-pip python3-venv lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip

--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip lsb-release gnupg curl
+sudo apt install python3-pip python3-venv lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip

--- a/jetty/install_ubuntu_src.md
+++ b/jetty/install_ubuntu_src.md
@@ -24,7 +24,7 @@ cases where the default option cannot be easily changed.
 Install tools needed by this tutorial:
 
 ```bash
-sudo apt install python3-pip lsb-release gnupg curl
+sudo apt install python3-pip python3-venv lsb-release gnupg curl
 ```
 
 ## vcstool and colcon from pip


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
By default python venvs maynot be installed in ubuntu. I ran into this issue when building from source.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
