### PR TITLE
Ionic Ubuntu source install: rosdep instructions

### DIFF
--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -104,8 +104,8 @@ sudo apt -y install \
 ```
 
 Alternatively, if you want to install dependencies using
-[rosdep](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html),
-ensure that [rosdep is installed](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html#how-do-i-use-the-rosdep-tool)
+[rosdep](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Rosdep.html),
+ensure that [rosdep is installed](https://docs.ros.org/en/rolling/Tutorials/Intermediate/Rosdep.html#how-do-i-use-the-rosdep-tool)
 and use the following command:
 
 ```bash

--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -119,11 +119,30 @@ and use the following command:
 
 ```bash
 cd ~/workspace/src
-# gz-tools2 can build from source against both gz-cmake3 and gz-cmake4
-# this workspace has only gz-cmake4
-# the gz-tools2 package.xml only lists gz-cmake3, so use --skip-keys gz-cmake3
-rosdep install -i --from-path . --skip-keys gz-cmake3
+rosdep install -i --from-path . -y \
+    --skip-keys "gz-cmake3 DART libogre-dev libogre-next-2.3-dev"
 ```
+
+The `rosdep` command attempts to install dependencies listed in `package.xml`
+files, but when problems arise the `--skip-keys` argument is used. Explanations
+for its use in the previous line are given below:
+
+* `gz-cmake3`: `gz-tools2` can build from source against
+  [both `gz-cmake3` and `gz-cmake4`](https://github.com/gazebosim/gz-tools/pull/128),
+  and this workspace only contains `gz-cmake4`. The `gz-tools2` `package.xml`
+  file only [depends on gz-cmake3](https://github.com/gazebosim/gz-tools/blob/2b228e5b956/package.xml#L13)
+  and since that package is not present, use `--skip-keys gz-cmake3`.
+* `DART`: `gz-physics8` can build against [dartsim](http://dartsim.github.io),
+  which is listed as DART in the [gz-physics package.xml file](https://github.com/gazebosim/gz-physics/blob/gz-physics8_8.0.0/package.xml#L16).
+  This package is not in the workspace, so `DART` is added to the `--skip-keys`
+  string.
+  See the discussion in [gz-physics#608](https://github.com/gazebosim/gz-physics/pull/608#discussion_r1589512231)
+  for more background on the package name used for `DART`.
+* `libogre-dev` and `libogre-next-2.3-dev`: `gz-rendering9` can build against
+  ogre 1.9 and ogre-next 2.3. The debian package names are listed as
+  dependencies in the [gz-rendering package.xml](https://github.com/gazebosim/gz-rendering/blob/gz-rendering9_9.0.0/package.xml#L22-L23)
+  but they are not available on all Linux versions, so work around with
+  `--skip-keys "libogre-dev libogre-next-2.3-dev"`.
 
 ## Building the Gazebo Libraries
 

--- a/ionic/install_ubuntu_src.md
+++ b/ionic/install_ubuntu_src.md
@@ -112,6 +112,19 @@ sudo apt -y install \
   $(sort -u $(find . -iname 'packages-'`lsb_release -cs`'.apt' -o -iname 'packages.apt' | grep -v '/\.git/') | sed '/gz\|sdf/d' | tr '\n' ' ')
 ```
 
+Alternatively, if you want to install dependencies using
+[rosdep](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html),
+ensure that [rosdep is installed](https://docs.ros.org/en/humble/Tutorials/Intermediate/Rosdep.html#how-do-i-use-the-rosdep-tool)
+and use the following command:
+
+```bash
+cd ~/workspace/src
+# gz-tools2 can build from source against both gz-cmake3 and gz-cmake4
+# this workspace has only gz-cmake4
+# the gz-tools2 package.xml only lists gz-cmake3, so use --skip-keys gz-cmake3
+rosdep install -i --from-path . --skip-keys gz-cmake3
+```
+
 ## Building the Gazebo Libraries
 
 Once the compiler and all the sources are in place it is time to compile them.


### PR DESCRIPTION
# 🎉 New feature

Add instructions for installing dependencies using rosdep.

## Summary

Our packages have `package.xml` files now, so users can use `rosdep` to install dependencies. Add instructions for Ionic with a `--skip-keys gz-cmake3` argument to handle workspaces with `gz-tools2` if users have the ROS apt repositories instead of packages.osrfoundation.org

## Test it

Follow the build-from-source instructions in a fresh container with [ROS rolling repositories](https://docs.ros.org/en/rolling/Installation/Alternatives/Ubuntu-Development-Setup.html#enable-required-repositories) but not packages.osrfoundation.org

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [X] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
