### PR TITLE
Update migrating_gazebo_classic_ros2_packages.md

### DIFF
--- a/migrating_gazebo_classic_ros2_packages.md
+++ b/migrating_gazebo_classic_ros2_packages.md
@@ -75,7 +75,7 @@ create a new branch in which we'll make the changes to migrate to the new
 Gazebo.
 
 ```bash
-git checkout -b new_gazebo
+git checkout -b feature-gazebo-sim-migration
 ```
 
 The changes we need to make are:


### PR DESCRIPTION
## Brief 

- Changed `git checkout -b new_gazebo` to `git checkout -b feature-gazebo-sim-migration`, Refer [turtlebot3_simulations](https://github.com/ROBOTIS-GIT/turtlebot3_simulations/tree/feature-gazebo-sim-migration) 
