### PR TITLE
Add jetty to nightly uploads job

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -27,6 +27,9 @@ jobs:
 
           - ubuntu_distribution: noble
             gazebo_distribution: ionic
+
+          - ubuntu_distribution: noble
+            gazebo_distribution: jetty
     steps:
       - uses: ros-tooling/setup-ros@v0.7
       - name: 'Set up Gazebo'
@@ -34,6 +37,7 @@ jobs:
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
           use-gazebo-nightly: ${{ matrix.gazebo_distribution == 'ionic'}}
+          use-gazebo-prerelease: ${{ matrix.gazebo_distribution == 'jetty'}}
       - name: 'Add Doxygen'
         run: sudo apt-get install -y doxygen graphviz texlive-latex-extra
       - name: 'Add missing dependencies'


### PR DESCRIPTION


# 🎉 New feature

Closes #<NUMBER>

## Summary

Updated to include Jetty

Also enabled prerelease binaries for jetty

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

