### PR TITLE
Update setup-gazebo

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: ros-tooling/setup-ros@v0.7
       - name: 'Set up Gazebo'
-        uses: gazebo-tooling/setup-gazebo@1f55cec330de851fa373f1ade8ac6b7ddfe6f013
+        uses: gazebo-tooling/setup-gazebo@v0.3.0
         with:
           required-gazebo-distributions: ${{ matrix.gazebo_distribution }}
           use-gazebo-prerelease: ${{ matrix.gazebo_distribution == 'jetty'}}


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
https://github.com/gazebosim/docs/actions/runs/17256885589/job/48970534652 failed because we're using an old setup-gazebo action which hardcoded the list of valid Gazebo releases.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

