### PR TITLE
Fix API doc generation for Jetty

### DIFF
--- a/.github/workflows/nightly-upload.yml
+++ b/.github/workflows/nightly-upload.yml
@@ -72,9 +72,12 @@ jobs:
       with:
         path: .api-docs
         pattern: api-docs-*
-        merge-multiple: true
+        merge-multiple: false
+    - uses: actions/setup-python@v5
+    - name: Install dependencies
+      run: pip install PyYAML
     - name: 'Restructure API Docs'
-      run: python3 tools/restructure_doxygen_artifacts.py ${{steps.download.outputs.download-path}} .api-out
+      run: python3 tools/restructure_doxygen_artifacts.py --input ${{steps.download.outputs.download-path}} .api-out
     - uses: actions/upload-artifact@v4
       with:
         name: api-docs

--- a/tools/restructure_doxygen_artifacts.py
+++ b/tools/restructure_doxygen_artifacts.py
@@ -4,57 +4,148 @@
 # Given a directory containing merged doxygen build artifacts, this script reorganizes them so they
 # can be deployed to the website
 # This assumes the following directory structure:
+# api-docs-fortress
 #   ignition-utils1
-#     doxygen
-#       html
-#   gz-utils2
 #     doxygen
 #       html
 #   ignition-math6
 #     doxygen
 #       html
+# api-docs-harmonic
+#   gz-utils2
+#     doxygen
+#       html
 #   gz-math7
 #     doxygen
 #       html
-#   ...
+# api-docs-jetty.
+#   gz-utils
+#     doxygen
+#       html
+#   gz-math
+#     doxygen
+#       html
+#
+# Note that starting Jetty, the directories will not have the version number.
+# Therefore, we rely on the index.yaml file at the root of this repo to obtain
+# the major version number of each library.
 #
 #   The result should look like
 #   utils
-#     1 (content of ignition-utils1/doxygen/html)
-#     2 (content of gz-utils2/doxygen/html)
+#     1 (content of **/ignition-utils1/doxygen/html)
+#     2 (content of **/gz-utils2/doxygen/html)
 #   math
-#     6 (content of ignition-math6/doxygen/html)
-#     7 (content of gz-math7/doxygen/html)
+#     6 (content of **/ignition-math6/doxygen/html)
+#     7 (content of **/gz-math7/doxygen/html)
+#
+#
+# To test, run:
+#
+# python3 restructure_doxygen_artifacts.py --gen-test-files api-docs
+# python3 restructure_doxygen_artifacts.py --input api-docs api-docs-merged
 
+import argparse
 import re
 import sys
-import pathlib
+from pathlib import Path
 import shutil
+import yaml
 
-input_dir = pathlib.Path(sys.argv[1])
-output_dir = pathlib.Path(sys.argv[2])
-output_dir.mkdir(exist_ok=True)
 
 re_expr = R"(?:ignition|gz)-([a-z_]*)(\d*)"
 sdf_re_expr = R"(sdformat)(\d*)"
+distro_re_expr = R"api-docs-([a-z]*)"
 
 
-def copy_library(lib_html, lib_name, lib_version):
+def copy_library(lib_html, lib_name, lib_version, output_dir: Path):
     output_lib_dir = output_dir / lib_name / lib_version
     output_lib_dir.mkdir(exist_ok=True, parents=True)
     print(f"{lib_html} -> {output_lib_dir}")
     shutil.copytree(lib_html, output_lib_dir, dirs_exist_ok=True)
 
+def build_version_map_from_index(index):
+    version_map = {}
+    for release in index['releases']:
+        name = release['name']
+        version_map[name] = {}
+        for lib in release['libraries']:
+            version_map[name][lib['name']] = lib['version']
 
-for lib in input_dir.iterdir():
-    m = re.match(re_expr, lib.name)
-    if not m:
-        m = re.match(sdf_re_expr, lib.name)
+    return version_map
 
-    if m:
-        lib_name, lib_version = m.groups()
-        lib_html = lib/"doxygen"/"html"
-        copy_library(lib_html, lib_name, lib_version)
-        # Handle gazebo->sim rename by making a copy into the sim directory
-        if lib_name == "gazebo":
-            copy_library(lib_html, "sim", lib_version)
+def restructure_docs(input_dir : Path, output_dir: Path, version_map):
+    output_dir.mkdir(exist_ok=True)
+    for api_docs in input_dir.iterdir():
+        m = re.match(distro_re_expr, api_docs.name)
+        if m:
+            distro = m.group(1)
+        else:
+            raise RuntimeError("Could not determine Gazebo distribution")
+
+
+        for lib in api_docs.iterdir():
+            m = re.match(re_expr, lib.name)
+            if not m:
+                m = re.match(sdf_re_expr, lib.name)
+
+            if m:
+                lib_name, lib_version = m.groups()
+                if not lib_version:
+                    lib_version = str(version_map[distro][lib_name])
+                    print("Could not determine version from library name. Using version from index", lib_version)
+
+                lib_html = lib/"doxygen"/"html"
+                copy_library(lib_html, lib_name, lib_version, output_dir)
+                # Handle gazebo->sim rename by making a copy into the sim directory
+                if lib_name == "gazebo":
+                    copy_library(lib_html, "sim", lib_version, output_dir)
+
+def _create_doxygen_dir(output_dir, distro, lib):
+    path = (output_dir / f"api-docs-{distro}" /lib/"doxygen"/"html")
+    print("Creating ", path)
+    path.mkdir(parents=True)
+    (path / "index.html").touch()
+
+def gen_test_files(output_dir):
+    output_dir.mkdir()
+    distro_lib = {
+        "fortress": ["ignition-utils1", "ignition-math6"],
+        "harmonic": ["gz-utils2", "gz-math7"],
+        "ionic": ["gz-cmake4", "gz-sim9"],
+        "jetty": ["gz-cmake", "gz-sim"]
+    }
+    for distro, libs in distro_lib.items():
+        for lib in libs:
+            _create_doxygen_dir(output_dir, distro, lib)
+
+def main(argv=None):
+    # We will assume that this file is in the same directory as documentation
+    # sources and conf.py files.
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("-i", "--input", dest="input_dir", help="Input directory")
+    group.add_argument("--gen-test-files", action="store_true", help="Generate test files")
+    parser.add_argument("output_dir", help="Output directory",)
+    parser.add_argument("--index", help="index.yaml file to use")
+
+    args = parser.parse_args(argv)
+
+    if args.gen_test_files:
+        gen_test_files(Path(args.output_dir))
+        return
+
+    if args.index:
+        index_path = Path(args.index)
+    else:
+        index_path = Path(__file__).parent.parent / "index.yaml"
+    if not index_path.exists():
+        raise RuntimeError("Could not find index.yaml")
+
+    with open(index_path, 'r') as f:
+        index = yaml.safe_load(f.read())
+        version_map = build_version_map_from_index(index)
+        restructure_docs(Path(args.input_dir), Path(args.output_dir), version_map)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #607 

## Summary

This relies on the `index.yaml` file at the root of this repo to determine the version number if it can be obtained from the build directory names. It sets `merge-multiple: false` in the download action so that the downloaded artifact will have the directory structure as shown in the comments at the top of the file:

https://github.com/gazebosim/docs/blob/a63b7b7945053dcf207dc12b70eaf579bb9cee86/tools/restructure_doxygen_artifacts.py#L7-L27

I've also added proper argument parsing and functionality to test this locally by generating test files using the `--gen-test-files` flag.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

