### PR TITLE
Update GUI_tutorial.md to correct jetty version

### DIFF
--- a/jetty/GUI_tutorial.md
+++ b/jetty/GUI_tutorial.md
@@ -29,7 +29,7 @@ For example, if you have Ionic (9.x.x), Harmonic (8.x.x), Garden (7.x.x), and Fo
 To ensure you're working with Jetty, include the `--force-version` directive when starting up:
 
 ```bash
-gz sim --force-version 9.0.0 shapes.sdf
+gz sim --force-version 10.0.0 shapes.sdf
 ```
 
 ## GUI


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
This fixes the documentation which suggested jetty was version 9 when it is actually version 10. 

No tests should be required, as this is just an update to the documentation. 

## Checklist
- [x] Signed all commits for DCO
- [x] Updated documentation (as needed)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.