### PR TITLE
Update spawn urdf tutorial

### DIFF
--- a/jetty/spawn_urdf.md
+++ b/jetty/spawn_urdf.md
@@ -47,7 +47,7 @@ The following command spawns the URDF file `model.urdf` into the Gazebo Sim worl
 gz service -s /world/empty/create --reqtype gz.msgs.EntityFactory --reptype gz.msgs.Boolean --timeout 1000 --req 'sdf_filename: "/path/to/model.urdf", name: "urdf_model"'
 ```
 
-If `model.urdf` is the URDF representation of [rrbot.xacro](https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro) in the `gazebo_ros_demos` package, executing the service call above should result in a simulation that now looks like this:
+If `model.urdf` is the URDF representation of [`rrbot.urdf`](https://github.com/gazebosim/docs/blob/master/jetty/tutorials/spawn_urdf/rrbot.urdf) in the `gazebo_ros_demos` package, executing the service call above should result in a simulation that now looks like this:
 
 ![urdf_spawned](tutorials/spawn_urdf/urdf_spawned.png)
 

--- a/jetty/tutorials/spawn_urdf/rrbot.urdf
+++ b/jetty/tutorials/spawn_urdf/rrbot.urdf
@@ -7,12 +7,13 @@
 <robot name="rrbot">
   <!-- Space btw top of beam and the each joint -->
   <!-- ros_control plugin -->
-  <gazebo>
+  <!-- Gazebo-classic plugins are manually commented out -->
+  <!-- gazebo>
     <plugin filename="libgazebo_ros_control.so" name="gazebo_ros_control">
       <robotNamespace>/rrbot</robotNamespace>
       <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
     </plugin>
-  </gazebo>
+  </gazebo -->
   <!-- Link1 -->
   <gazebo reference="link1">
     <material>Gazebo/Orange</material>
@@ -65,10 +66,11 @@
           <stddev>0.01</stddev>
         </noise>
       </ray>
-      <plugin filename="libgazebo_ros_gpu_laser.so" name="gazebo_ros_head_hokuyo_controller">
+      <!-- Gazebo-classic plugins are manually commented out -->
+      <!-- plugin filename="libgazebo_ros_gpu_laser.so" name="gazebo_ros_head_hokuyo_controller">
         <topicName>/rrbot/laser/scan</topicName>
         <frameName>hokuyo_link</frameName>
-      </plugin>
+      </plugin -->
     </sensor>
   </gazebo>
   <!-- camera -->
@@ -95,16 +97,14 @@
           <stddev>0.007</stddev>
         </noise>
       </camera>
-      <plugin filename="libgazebo_ros_camera.so" name="camera_controller">
+      <!-- Gazebo-classic plugins are manually commented out -->
+      <!-- plugin filename="libgazebo_ros_camera.so" name="camera_controller">
         <alwaysOn>true</alwaysOn>
         <updateRate>0.0</updateRate>
         <cameraName>rrbot/camera1</cameraName>
         <imageTopicName>image_raw</imageTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
         <frameName>camera_link_optical</frameName>
-        <!-- setting hackBaseline to anything but 0.0 will cause a misalignment
-            between the gazebo sensor image and the frame it is supposed to
-            be attached to -->
         <hackBaseline>0.0</hackBaseline>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>
@@ -115,7 +115,7 @@
         <Cx>0.0</Cx>
         <Cy>0.0</Cy>
         <focalLength>0.0</focalLength>
-      </plugin>
+      </plugin -->
     </sensor>
   </gazebo>
   <material name="black">
@@ -242,7 +242,10 @@
     <visual>
       <origin rpy="0 0 0" xyz="0 0 0"/>
       <geometry>
-        <mesh filename="package://rrbot_description/meshes/hokuyo.dae"/>
+        <!-- hokuyo.dae is manually replaced by a simple box geom to allow
+             this to spawn without rrbot_description package -->
+        <!-- mesh filename="package://rrbot_description/meshes/hokuyo.dae"/ -->
+        <box>0.1 0.1 0.1</box>
       </geometry>
     </visual>
     <inertial>


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🦟 Bug fix

Fixes #<NUMBER>

## Summary

The rrbot.urdf includes old gazebo classic plugins and reference to rrbot_description package which are not available and causes gz-sim to output errors. This PR removes unsupported plugins and unavailable mesh from `rrobot.urdf` to get rid off those errors.

It also updated one of the links to the `rrobot.urdf` to the version from this repo so that it's consistent with the link earlier in this tutorial.

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

Generated-by: Remove this if GenAI was not used.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

