### PR TITLE
Jetty Release: Make Jetty the default version

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -119,10 +119,10 @@ pages:
 releases:
   - name: jetty
     lts: true
-    dev: true
+    dev: false
     eol: false
-    preferred: false # Only one preferred=true is allowed
-    description: Upcoming release, under development.
+    preferred: true # Only one preferred=true is allowed
+    description: Supported Sep, 2025 to Sep, 2030
     libraries:
       - name: cmake
         version: 5
@@ -159,7 +159,7 @@ releases:
   - name: ionic
     lts: false
     eol: false
-    preferred: true # Only one preferred=true is allowed
+    preferred: false # Only one preferred=true is allowed
     description: Supported Sep, 2024 to Sep, 2026
     libraries:
       - name: cmake


### PR DESCRIPTION
Part of https://github.com/gazebosim/gz-jetty/issues/66